### PR TITLE
Fix: use ReadAuthSettings to get authSettings

### DIFF
--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -16,7 +16,7 @@ func NewDatasource(ctx context.Context, dsInstanceSettings backend.DataSourceIns
 	plog := backend.NewLoggerWith("logger", "tsdb.prometheus-amazon")
 	plog.Debug("Initializing")
 
-	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+	authSettings := awsds.ReadAuthSettings(ctx)
 	return &Datasource{
 		Service:      promlib.NewService(sdkhttpclient.NewProvider(), plog, extendClientOpts),
 		authSettings: *authSettings,


### PR DESCRIPTION
Uses ReadAuthSettings which tries to read auth settings from context first and then automatically falls back to reading auth settings from the environment.