### PR TITLE
Auth: Only allow users to use sigv4 auth

### DIFF
--- a/src/configuration/DataSourceHttpSettingsOverhaul.tsx
+++ b/src/configuration/DataSourceHttpSettingsOverhaul.tsx
@@ -41,7 +41,7 @@ export const DataSourceHttpSettingsOverhaul = (props: Props) => {
   const sigV4Option: CustomMethod = {
     id: sigV4Id,
     label: 'SigV4 auth',
-    description: 'Use SigV4 authentication to connect to to your Amazon Managed Service for Prometheus data source.',
+    description: 'Use SigV4 authentication to connect to your Amazon Managed Service for Prometheus workspace',
     component: <>{renderSigV4Editor}</>,
   };
 


### PR DESCRIPTION
Only render the SigV4 auth in the config page.

![Screenshot 2024-07-24 at 12 04 20 PM](https://github.com/user-attachments/assets/49f692a9-a8c0-41b4-b7f3-9fea8d4e052f)
![Screenshot 2024-07-24 at 12 04 39 PM](https://github.com/user-attachments/assets/99ca4196-a717-4be8-ab09-f92f7a42d77c)
