### PR TITLE
Update docs

### DIFF
--- a/src/configuration/ConfigEditor.tsx
+++ b/src/configuration/ConfigEditor.tsx
@@ -27,8 +27,7 @@ export const ConfigEditor = (props: Props) => {
       )}
       <DataSourceDescription
         dataSourceName="Amazon Managed Service for Prometheus"
-        // TODO: point this at the new plugin's docs or README  }
-        docsLink="https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/"
+        docsLink="https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/"
       />
       <hr className={`${styles.hrTopSpace} ${styles.hrBottomSpace}`} />
       <DataSourceHttpSettingsOverhaul
@@ -61,8 +60,7 @@ export const ConfigEditor = (props: Props) => {
  * @returns
  */
 export function docsTip(url?: string) {
-  /* TODO: point this at the new plugin's docs or README */
-  const docsUrl = 'https://grafana.com/docs/grafana/latest/datasources/prometheus/#configure-the-data-source';
+  const docsUrl = 'https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/';
 
   return (
     <a href={url ? url : docsUrl} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Not sure if this the correct docs to link to here.

Maybe instead we need to also [update the naming in the grafana docs](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/) first and then update these links accordingly? Happy to take that on if that is the case 👍 

Fixes https://github.com/grafana/grafana-amazonprometheus-datasource/issues/182