### PR TITLE
Update combine-prs.yml

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -18,4 +18,5 @@ jobs:
         uses: github/combine-prs@v5.1.0
         with:
           labels: combined-pr
+          pr_title: "Dependabot updates"
           branch_prefix: dependabot # the default, just for clarity


### PR DESCRIPTION
This is just a suggestion, since the current "Combined PRs" title isn't that clear on what's being combined. This title ends up being the default commit message of the squashed commit and ends up in the Changelog. I know that this action could be set to combine any branches, but it's only dependabot right now and I don't see us using it for anything but that, right? 
Suggestions for other titles welcome too. 