### PR TITLE
Chore: Add plugin.json keywords

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -84,9 +84,7 @@
   "info": {
     "version": "%VERSION%",
     "updated": "%TODAY%",
-    "keywords": [
-      "datasource"
-    ],
+    "keywords": ["datasource", "aws", "amazon", "prometheus", "cloud provider", "database", "metrics", "time series"],
     "description": "Open source time series database & alerting",
     "author": {
       "name": "Grafana Labs",


### PR DESCRIPTION
Add plugin.json keywords to include "amazon" + "aws" + "cloud provider" + "database" etc

Related to https://github.com/grafana/oss-plugin-partnerships/issues/1055