### PR TITLE
Chore: group dependabot updates and use a weekly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,30 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
-      dependencies:
+      grafana-dependencies:
         patterns:
           - "@grafana/*"
-      dev-dependencies:
+      grafana-dev-dependencies:
         patterns:
           - "@grafana/e2e*"
+      all-dependencies:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      grafana-dependencies:
-        patterns:
-          - "@grafana/*"
-      grafana-dev-dependencies:
-        patterns:
-          - "@grafana/e2e*"
       all-dependencies:
         patterns:
           - '*'


### PR DESCRIPTION
- Groups updates according to the package ecosystem
- Sets update interval to be weekly (this will be Mondays by default)