### PR TITLE
Update compatibility info in plugin.json

### DIFF
--- a/e2e/query-editor.spec.ts
+++ b/e2e/query-editor.spec.ts
@@ -411,11 +411,11 @@ test.describe('Prometheus query editor', () => {
         .getByGrafanaSelector(selectors.components.DataSource.Prometheus.queryEditor.builder.metricSelect)
         .click();
 
-      await page.getByText('Metrics explorer', { exact: true }).click();
+      // await page.getByText('Metrics explorer', { exact: true }).click();
 
-      await expect(
-        explorePage.getByGrafanaSelector(selectors.components.DataSource.Prometheus.queryEditor.builder.metricsExplorer)
-      ).toBeVisible();
+      // await expect(
+      //   explorePage.getByGrafanaSelector(selectors.components.DataSource.Prometheus.queryEditor.builder.metricsExplorer)
+      // ).toBeVisible();
     });
 
     // NEED TO COMPLETE QUEY ADVISOR WORK OR FIGURE OUT HOW TO ENABLE EXPERIMENTAL FEATURE TOGGLES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-amazonprometheus-datasource",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A plugin for Amazon Managed Prometheus",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -102,7 +102,7 @@
     ]
   },
   "dependencies": {
-    "grafanaDependency": ">=11.0.0",
+    "grafanaDependency": "<=11.4.x",
     "plugins": []
   }
 }


### PR DESCRIPTION
The metrics explorer test fails in e2e test for grafana-dev@11.5 because of a feature toggle that was removed in 11.5. There isn't an easy fix for this without waiting for grafana 11.6. We've decided to disable the test and make sure this version of AMP has accurate compatibility info. 
When we release the new version of AMP from this [PR](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/319) (with the updated prometheus frontend library): , it will have `grafanaDependency>=11.5.x`. 

