### PR TITLE
Prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0
+
+- Update promlib to v0.0.7 and grafana/prometheus to 11.5.0-218678 [#319](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/319)
+- Bump golang.org/x/net from 0.31.0 to 0.33.0 in the go_modules group [#329](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/329)
+- Chore: Add react and react-dom major updates to dependabot ignore [#331](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/331)
+
 ## 1.0.5
 
 - Update compatibility info in plugin.json in [#327](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/327)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-amazonprometheus-datasource",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "A plugin for Amazon Managed Prometheus",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,7 @@
+## Compatibility
+
+Amazon Managed Service for Prometheus 2.0.0 is not compatible with Grafana<11.5.0 If you are running version 11.4.x and lower, please use plugin version 1.0.5
+
 # Amazon Managed Service for Prometheus Data Source
 
 Amazon Managed Service for Prometheus is a Prometheus-compatible service that monitors and provides alerts on containerized applications and infrastructure at scale.


### PR DESCRIPTION
Incrementing a major version, since [Update promlib to v0.0.7 and grafana/prometheus to 11.5.0-218678](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/319) is a breaking change for users using grafana <=11.4.0