### PR TITLE
fix action input names

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -31,8 +31,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ env.AWS_DS_TOKEN_CREATOR_ID }}
-          private_key: ${{ env.AWS_DS_TOKEN_CREATOR_PEM }}
+          app-id: ${{ env.AWS_DS_TOKEN_CREATOR_ID }}
+          private-key: ${{ env.AWS_DS_TOKEN_CREATOR_PEM }}
       - name: Run Commands
         uses: ./actions/commands
         with:


### PR DESCRIPTION
Use the correct inputs (change `_` to `-`)
`app_id` -> `app-id`
`private_key` -> `private-key`

To fix https://github.com/grafana/grafana-amazonprometheus-datasource/actions/runs/16811987377/job/47619332839#step:5:1