### PR TITLE
Publish to every environment on Cloud and Add On-Prem promotion

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,13 +8,13 @@ on:
         description: Branch to publish from. Can be used to deploy PRs to dev
         default: main
       environment:
-        description: Environment to publish to
+        description: Environment will always publish to all waves (dev + ops + prod). Cloud will publish scoped only to Grafana Cloud, On Prem will publish with Universal scope. Please use Cloud unless emergency fix needed for On Prem customer.
         required: true
         type: choice
+        default: 'cloud (recommended)'
         options:
-          - 'dev'
-          - 'ops'
-          - 'prod'
+          - 'cloud (recommended)'
+          - 'on-prem (for emergencies fix to On Prem customers)'
       docs-only:
         description: Only publish docs, do not publish the plugin
         default: false
@@ -24,6 +24,10 @@ permissions: {}
 
 jobs:
   cd:
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, ops, prod]
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3
     permissions:
@@ -32,8 +36,9 @@ jobs:
       attestations: write
     with:
       branch: ${{ github.event.inputs.branch }}
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ matrix.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      scopes: universal
-      golangci-lint-version: 2.1.6
-      github-draft-release: false # publish the github release directly, skipping the draft
+      scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
+      go-version: '1.24'
+      golangci-lint-version: '2.1.6'
+      github-draft-release: false # publish the github release directly, skipping the draft step


### PR DESCRIPTION
This PR is to align the publishing of external datasources with the new argo cd workflows that promote changes through cloud before on prem.

This changes the choice from dev + ops + prod to cloud or on-prem. Cloud will only scope the publish to grafana cloud, on prem will make it available to all customers.

Automations will be in place to promote the new version to on prem after its been rolled out to all of production but the option exists if you need to do this quickly.

Related to https://github.com/grafana/data-sources/issues/778