### PR TITLE
Fix i18n initialization in dev builds

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -227,10 +227,6 @@ const config = async (env: Env): Promise<Configuration> => {
 
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      alias: {
-        '@grafana/i18n$': path.resolve(process.cwd(), 'node_modules/@grafana/i18n'),
-        'react-i18next$': path.resolve(process.cwd(), 'node_modules/react-i18next'),
-      },
       // handle resolving "rootDir" paths
       modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
       unsafeCache: true,

--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -227,6 +227,10 @@ const config = async (env: Env): Promise<Configuration> => {
 
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      alias: {
+        '@grafana/i18n$': path.resolve(process.cwd(), 'node_modules/@grafana/i18n'),
+        'react-i18next$': path.resolve(process.cwd(), 'node_modules/react-i18next'),
+      },
       // handle resolving "rootDir" paths
       modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
       unsafeCache: true,

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -2,6 +2,18 @@
 import './.config/jest-setup';
 import { TextEncoder, TextDecoder } from 'util';
 
+if (typeof window !== 'undefined' && !window.grafanaBootData) {
+  window.grafanaBootData = {
+    settings: {
+      featureToggles: {},
+    },
+    user: {
+      locale: 'en-US',
+    },
+    navTree: [],
+  };
+}
+
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "3.0.0",
   "description": "A plugin for Amazon Managed Prometheus",
   "scripts": {
-    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "e2e": "playwright test",
     "e2e:ui": "yarn playwright test --ui",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@grafana/aws-sdk": "^0.10.2",
     "@grafana/data": "12.4.2",
     "@grafana/plugin-ui": "^0.13.1",
-    "@grafana/prometheus": "12.4.2",
+    "@grafana/prometheus": "13.1.4",
     "@grafana/runtime": "12.4.2",
     "@grafana/schema": "12.4.2",
     "@grafana/ui": "12.4.2",

--- a/src/configuration/DataSourceOptions.ts
+++ b/src/configuration/DataSourceOptions.ts
@@ -2,5 +2,6 @@ import { PromOptions } from '@grafana/prometheus';
 
 export interface DataSourceOptions extends PromOptions {
   'prometheus-type-migration'?: boolean;
+  sigV4Auth?: boolean;
   sigv4Service?: string;
 }

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -1,7 +1,76 @@
 import { plugin as PrometheusDatasourcePlugin } from './module';
 
+declare const process: {
+  env: {
+    NODE_ENV?: string;
+  };
+};
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+jest.mock('@grafana/i18n', () => ({
+  ...jest.requireActual('@grafana/i18n'),
+  initPluginTranslations: jest.fn(),
+}));
+
+jest.mock('@grafana/prometheus', () => ({
+  loadResources: jest.fn(),
+  PromCheatSheet: jest.fn(),
+  PrometheusDatasource: jest.fn(),
+  PromQueryEditorByApp: jest.fn(),
+}));
+
+jest.mock('./configuration/ConfigEditor', () => ({
+  ConfigEditor: jest.fn(),
+}));
+
 describe('module', () => {
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
   it('should have metrics query field in panels and Explore', () => {
     expect(PrometheusDatasourcePlugin.components.QueryEditor).toBeDefined();
+  });
+
+  it('should skip translation initialization when running tests', () => {
+    process.env.NODE_ENV = 'test';
+    let initPluginTranslations: jest.Mock | undefined;
+
+    jest.isolateModules(() => {
+      require('./module');
+      initPluginTranslations = require('@grafana/i18n').initPluginTranslations;
+    });
+
+    expect(initPluginTranslations).not.toHaveBeenCalled();
+  });
+
+  it('should initialize plugin translations outside tests', () => {
+    process.env.NODE_ENV = 'development';
+    let initPluginTranslations: jest.Mock | undefined;
+
+    jest.isolateModules(() => {
+      require('./module');
+      initPluginTranslations = require('@grafana/i18n').initPluginTranslations;
+    });
+
+    expect(initPluginTranslations).toHaveBeenCalledTimes(1);
+    expect(initPluginTranslations).toHaveBeenCalledWith('grafana-amazonprometheus-datasource', [expect.any(Function)]);
+  });
+
+  it('should not await translation initialization', () => {
+    process.env.NODE_ENV = 'development';
+    const neverResolvingPromise = new Promise(() => {});
+
+    expect(() => {
+      jest.isolateModules(() => {
+        const { initPluginTranslations } = require('@grafana/i18n');
+        initPluginTranslations.mockReturnValue(neverResolvingPromise);
+
+        require('./module');
+      });
+    }).not.toThrow();
   });
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,11 +1,22 @@
 import { DataSourcePlugin } from '@grafana/data';
-import { PromQueryEditorByApp, PrometheusDatasource, PromCheatSheet } from '@grafana/prometheus';
+import { initPluginTranslations } from '@grafana/i18n';
+import { loadResources, PromCheatSheet, PrometheusDatasource, PromQueryEditorByApp } from '@grafana/prometheus';
 
 // custom config made with sigV4 auth
 import { ConfigEditor } from './configuration/ConfigEditor';
+import pluginJson from './plugin.json';
 
+declare const process: {
+  env: {
+    NODE_ENV?: string;
+  };
+};
 
-export const plugin = new DataSourcePlugin(PrometheusDatasource) 
+if (process.env.NODE_ENV !== 'test') {
+  void initPluginTranslations(pluginJson.id, [loadResources]);
+}
+
+export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryEditor(PromQueryEditorByApp)
   .setConfigEditor(ConfigEditor)
   .setQueryEditorHelp(PromCheatSheet);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+
+import type { Configuration } from 'webpack';
+import { merge } from 'webpack-merge';
+
+import grafanaConfig, { type Env } from './.config/webpack/webpack.config';
+
+const config = async (env: Env): Promise<Configuration> => {
+  const baseConfig = await grafanaConfig(env);
+
+  return merge(baseConfig, {
+    resolve: {
+      // Force @grafana/i18n and react-i18next to a single canonical path.
+      // @grafana/prometheus installs its own nested copies; only one gets
+      // initialized by initPluginTranslations(), causing t() errors in dev.
+      alias: {
+        '@grafana/i18n$': path.resolve(__dirname, 'node_modules/@grafana/i18n'),
+        'react-i18next$': path.resolve(__dirname, 'node_modules/react-i18next'),
+      },
+    },
+  });
+};
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,7 +1398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:^2.1.6":
+"@floating-ui/react-dom@npm:^2.1.6, @floating-ui/react-dom@npm:^2.1.8":
   version: 2.1.8
   resolution: "@floating-ui/react-dom@npm:2.1.8"
   dependencies:
@@ -1421,6 +1421,20 @@ __metadata:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
   checksum: 10c0/a026266d8875e69de1ac1e1a00588660c8ee299c1e7d067c5c5fd1d69a46fd10acff5dd6cb66c3fe40a3347b443234309ba95f5b33d49059d0cda121f558f566
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:0.27.19":
+  version: 0.27.19
+  resolution: "@floating-ui/react@npm:0.27.19"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10c0/2a2cdfd3e67e0606833b63f922ad2a9037974f22b944e1cb8c0991b4c40450f8413d69745c0bbf4646e5ba283747f60d2fdc9a8d289b68b24448e59d81a3a96d
   languageName: node
   linkType: hard
 
@@ -1649,35 +1663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-ui@npm:^0.12.1":
-  version: 0.12.1
-  resolution: "@grafana/plugin-ui@npm:0.12.1"
-  dependencies:
-    "@emotion/css": "npm:^11.11.2"
-    "@hello-pangea/dnd": "npm:^17.0.0"
-    "@react-awesome-query-builder/ui": "npm:^6.6.4"
-    "@types/prismjs": "npm:^1.26.4"
-    lodash: "npm:^4.17.21"
-    prismjs: "npm:^1.30.0"
-    react-calendar: "npm:^4.8.0"
-    react-popper-tooltip: "npm:^4.4.2"
-    react-use: "npm:^17.3.1"
-    react-virtualized-auto-sizer: "npm:^1.0.6"
-    sql-formatter-plus: "npm:^1.3.6"
-    uuid: "npm:^11.0.0"
-  peerDependencies:
-    "@grafana/data": ">=10.4.0"
-    "@grafana/e2e-selectors": ">=10.4.0"
-    "@grafana/runtime": ">=10.4.0"
-    "@grafana/ui": ">=10.4.0"
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rxjs: ^7.8.1
-  checksum: 10c0/4d88c6cb7c883521d1bd7eba815674038951e77643ea3050f1355a16ce507ce593e2c267073e842f1d6974a486151420054adf1a813e44fa75284972aa94e243
-  languageName: node
-  linkType: hard
-
-"@grafana/plugin-ui@npm:^0.13.0, @grafana/plugin-ui@npm:^0.13.1":
+"@grafana/plugin-ui@npm:0.13.1, @grafana/plugin-ui@npm:^0.13.0, @grafana/plugin-ui@npm:^0.13.1":
   version: 0.13.1
   resolution: "@grafana/plugin-ui@npm:0.13.1"
   dependencies:
@@ -1709,36 +1695,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/prometheus@npm:12.4.2":
-  version: 12.4.2
-  resolution: "@grafana/prometheus@npm:12.4.2"
+"@grafana/prometheus@npm:13.1.4":
+  version: 13.1.4
+  resolution: "@grafana/prometheus@npm:13.1.4"
   dependencies:
     "@emotion/css": "npm:11.13.5"
-    "@floating-ui/react": "npm:0.27.16"
-    "@grafana/data": "npm:12.4.2"
-    "@grafana/e2e-selectors": "npm:12.4.2"
-    "@grafana/i18n": "npm:12.4.2"
-    "@grafana/plugin-ui": "npm:^0.12.1"
-    "@grafana/runtime": "npm:12.4.2"
-    "@grafana/schema": "npm:12.4.2"
-    "@grafana/ui": "npm:12.4.2"
+    "@floating-ui/react": "npm:0.27.19"
+    "@grafana/plugin-ui": "npm:0.13.1"
     "@hello-pangea/dnd": "npm:18.0.1"
     "@leeoniya/ufuzzy": "npm:1.0.19"
-    "@lezer/common": "npm:1.3.0"
+    "@lezer/common": "npm:1.5.2"
     "@lezer/highlight": "npm:1.2.3"
-    "@lezer/lr": "npm:1.4.3"
+    "@lezer/lr": "npm:1.4.8"
     "@prometheus-io/lezer-promql": "npm:0.307.3"
-    "@reduxjs/toolkit": "npm:2.10.1"
-    "@types/debounce-promise": "npm:3.1.9"
-    "@types/lodash": "npm:4.17.20"
-    "@types/react": "npm:18.3.18"
-    "@types/react-dom": "npm:18.3.5"
-    "@types/react-highlight-words": "npm:0.20.0"
-    "@types/react-window": "npm:1.8.8"
-    "@types/semver": "npm:7.7.1"
-    "@types/uuid": "npm:10.0.0"
     debounce-promise: "npm:3.1.2"
-    lodash: "npm:^4.17.23"
+    lodash: "npm:4.18.1"
     moment: "npm:2.30.1"
     moment-timezone: "npm:0.5.47"
     monaco-editor: "npm:0.34.1"
@@ -1750,11 +1721,17 @@ __metadata:
     react-window: "npm:1.8.11"
     rxjs: "npm:7.8.2"
     semver: "npm:7.7.3"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
   peerDependencies:
+    "@grafana/data": ">=11.5.0"
+    "@grafana/e2e-selectors": ">=11.5.0"
+    "@grafana/i18n": ">=12.3.0"
+    "@grafana/runtime": ">=11.5.0"
+    "@grafana/schema": ">=11.5.0"
+    "@grafana/ui": ">=11.5.0"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10c0/731df004ac179eb9cfcfe2880b844922c766a6ad4f51ff9742cd91c5533bf132fe16172ad7bed884b760a4e6813585d0215acd0711b58a19b947a102d1881bba
+  checksum: 10c0/c773dffe917180d1fc73c00f313a86dc64deced61d81bd2d805bf3bf87475ef8d70d87ada05ec9ae71d18b06fa991aca222a8c8f6ce00026474d9e4072f62bc5
   languageName: node
   linkType: hard
 
@@ -2423,14 +2400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@lezer/common@npm:1.3.0"
-  checksum: 10c0/e164094920761c2f56c8634d0ae9261ea7c5e6b8202aa08773febc59b8d8284dde5bc7a810c9438e27b978e5ad67d0db03af1ed72924df61b8fa2704acb55deb
-  languageName: node
-  linkType: hard
-
-"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.3.0":
+"@lezer/common@npm:1.5.2, @lezer/common@npm:^1.0.0, @lezer/common@npm:^1.3.0":
   version: 1.5.2
   resolution: "@lezer/common@npm:1.5.2"
   checksum: 10c0/e39b46d74899409eab549df7942f00cd8c7f46c81ef0e2f079654ca96d262fca009927328bcd500d69270f5f09986e74768bed19c0acaadbd22f1a6c7dd9bd85
@@ -2446,12 +2416,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/lr@npm:1.4.3":
-  version: 1.4.3
-  resolution: "@lezer/lr@npm:1.4.3"
+"@lezer/lr@npm:1.4.8":
+  version: 1.4.8
+  resolution: "@lezer/lr@npm:1.4.8"
   dependencies:
     "@lezer/common": "npm:^1.0.0"
-  checksum: 10c0/3c9fd7eefb0641addfdd0955b4c4014bb8702285c52890b58c937d766320ba2fec8c6b374b46f514079a093c9dd21b6632746a01fed16c250c90d649e5dd12c1
+  checksum: 10c0/8bd2228a316a5ef8da01908e3e22aca95fa9695211ffe56f3e8be756b37d0810d5aa91fbbdd274b198a343051d8637e130e26f51161161f089244af242b653c9
   languageName: node
   linkType: hard
 
@@ -3502,28 +3472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@npm:2.10.1":
-  version: 2.10.1
-  resolution: "@reduxjs/toolkit@npm:2.10.1"
-  dependencies:
-    "@standard-schema/spec": "npm:^1.0.0"
-    "@standard-schema/utils": "npm:^0.3.0"
-    immer: "npm:^10.2.0"
-    redux: "npm:^5.0.1"
-    redux-thunk: "npm:^3.1.0"
-    reselect: "npm:^5.1.0"
-  peerDependencies:
-    react: ^16.9.0 || ^17.0.0 || ^18 || ^19
-    react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-redux:
-      optional: true
-  checksum: 10c0/0296a73c8dfbe8b2a14095cfaaf67a8e4c5537b164c021bdb81c43922d10042a2fe733fbdfc956f9233884a6db5491fbc6d950a8883e1cd6137251db392f6a9e
-  languageName: node
-  linkType: hard
-
 "@remix-run/router@npm:1.23.2":
   version: 1.23.2
   resolution: "@remix-run/router@npm:1.23.2"
@@ -3603,20 +3551,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10c0/7ff90c97baf3b434028d2c8c401b542771fbc5f54af07887ca869656d20dfa1284bff9c22b08064b932df88f33b0f98774741762788756edac0f08b6bccd5207
-  languageName: node
-  linkType: hard
-
-"@standard-schema/spec@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@standard-schema/spec@npm:1.1.0"
-  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
-  languageName: node
-  linkType: hard
-
-"@standard-schema/utils@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@standard-schema/utils@npm:0.3.0"
-  checksum: 10c0/6eb74cd13e52d5fc74054df51e37d947ef53f3ab9e02c085665dcca3c38c60ece8d735cebbdf18fbb13c775fbcb9becb3f53109b0e092a63f0f7389ce0993fd0
   languageName: node
   linkType: hard
 
@@ -3986,13 +3920,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debounce-promise@npm:3.1.9":
-  version: 3.1.9
-  resolution: "@types/debounce-promise@npm:3.1.9"
-  checksum: 10c0/ea83d13c367a2bc52cf5535d5f4567df25a7e1ed2ef2381bbebb939dfd378b433b523092d4b11d2f531bc2c2a2dd4b10ca04e7bbd450cd8b140293faa03fc189
-  languageName: node
-  linkType: hard
-
 "@types/eslint-scope@npm:^3.7.7":
   version: 3.7.7
   resolution: "@types/eslint-scope@npm:3.7.7"
@@ -4174,30 +4101,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:18.3.5":
-  version: 18.3.5
-  resolution: "@types/react-dom@npm:18.3.5"
-  peerDependencies:
-    "@types/react": ^18.0.0
-  checksum: 10c0/b163d35a6b32a79f5782574a7aeb12a31a647e248792bf437e6d596e2676961c394c5e3c6e91d1ce44ae90441dbaf93158efb4f051c0d61e2612f1cb04ce4faa
-  languageName: node
-  linkType: hard
-
 "@types/react-dom@npm:18.3.7":
   version: 18.3.7
   resolution: "@types/react-dom@npm:18.3.7"
   peerDependencies:
     "@types/react": ^18.0.0
   checksum: 10c0/8bd309e2c3d1604a28a736a24f96cbadf6c05d5288cfef8883b74f4054c961b6b3a5e997fd5686e492be903c8f3380dba5ec017eff3906b1256529cd2d39603e
-  languageName: node
-  linkType: hard
-
-"@types/react-highlight-words@npm:0.20.0":
-  version: 0.20.0
-  resolution: "@types/react-highlight-words@npm:0.20.0"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/95d268fc24f4ad43e1b4c5be41f66b6401b90977fd4e2c9de37bf696b0c97fd216c1f6c4a833236886183dbda766d3d0485333997ac193360c35a2a36f46534b
   languageName: node
   linkType: hard
 
@@ -4219,31 +4128,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-window@npm:1.8.8":
-  version: 1.8.8
-  resolution: "@types/react-window@npm:1.8.8"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/2170a3957752603e8b994840c5d31b72ddf94c427c0f42b0175b343cc54f50fe66161d8871e11786ec7a59906bd33861945579a3a8f745455a3744268ec1069f
-  languageName: node
-  linkType: hard
-
 "@types/react@npm:*":
   version: 19.2.14
   resolution: "@types/react@npm:19.2.14"
   dependencies:
     csstype: "npm:^3.2.2"
   checksum: 10c0/7d25bf41b57719452d86d2ac0570b659210402707313a36ee612666bf11275a1c69824f8c3ee1fdca077ccfe15452f6da8f1224529b917050eb2d861e52b59b7
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:18.3.18":
-  version: 18.3.18
-  resolution: "@types/react@npm:18.3.18"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/8fb2b00672072135d0858dc9db07873ea107cc238b6228aaa2a9afd1ef7a64a7074078250db38afbeb19064be8ea6af5eac32d404efdd5f45e093cc4829d87f8
   languageName: node
   linkType: hard
 
@@ -4317,13 +4207,6 @@ __metadata:
   version: 0.0.6
   resolution: "@types/use-sync-external-store@npm:0.0.6"
   checksum: 10c0/77c045a98f57488201f678b181cccd042279aff3da34540ad242f893acc52b358bd0a8207a321b8ac09adbcef36e3236944390e2df4fcedb556ce7bb2a88f2a8
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
   languageName: node
   linkType: hard
 
@@ -8140,7 +8023,7 @@ __metadata:
     "@grafana/eslint-config": "npm:9.0.0"
     "@grafana/plugin-e2e": "npm:3.4.12"
     "@grafana/plugin-ui": "npm:^0.13.1"
-    "@grafana/prometheus": "npm:12.4.2"
+    "@grafana/prometheus": "npm:13.1.4"
     "@grafana/runtime": "npm:12.4.2"
     "@grafana/schema": "npm:12.4.2"
     "@grafana/tsconfig": "npm:2.0.1"
@@ -8492,13 +8375,6 @@ __metadata:
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
-  languageName: node
-  linkType: hard
-
-"immer@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "immer@npm:10.2.0"
-  checksum: 10c0/35e66b0585b2aec4e85ae7a993f049405f170799ba89d79205bc3fdae2c5bdaa2b1d35f62803d8beee42b7e85c7f7315a6e93b6a5a510c5a46f03dbe63619e87
   languageName: node
   linkType: hard
 
@@ -11638,15 +11514,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-thunk@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "redux-thunk@npm:3.1.0"
-  peerDependencies:
-    redux: ^5.0.0
-  checksum: 10c0/21557f6a30e1b2e3e470933247e51749be7f1d5a9620069a3125778675ce4d178d84bdee3e2a0903427a5c429e3aeec6d4df57897faf93eb83455bc1ef7b66fd
-  languageName: node
-  linkType: hard
-
 "redux@npm:^4.2.1":
   version: 4.2.1
   resolution: "redux@npm:4.2.1"
@@ -11718,13 +11585,6 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
-  languageName: node
-  linkType: hard
-
-"reselect@npm:^5.1.0":
-  version: 5.1.1
-  resolution: "reselect@npm:5.1.1"
-  checksum: 10c0/219c30da122980f61853db3aebd173524a2accd4b3baec770e3d51941426c87648a125ca08d8c57daa6b8b086f2fdd2703cb035dd6231db98cdbe1176a71f489
   languageName: node
   linkType: hard
 
@@ -13459,6 +13319,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+  languageName: node
+  linkType: hard
+
+"uuid@npm:14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Alias `@grafana/i18n` and `react-i18next` in the existing webpack config so dev builds use Grafana shared i18n instance.
- Initialize plugin translations from `src/module.ts` outside Jest using the Prometheus `loadResources` helper.
- Add module tests for test-mode skip, non-test initialization, and non-awaited bootstrap behavior.

## Root cause
Running `yarn run dev` could bundle `@grafana/i18n` through `@grafana/prometheus/node_modules`, so calls to `t()` happened against a duplicate/uninitialized i18n instance. In the datasource edit UI this surfaced as `t() was called before i18n was initialized` followed by `Could not load plugin`, leaving the config form missing.

## Verification
- Before fix:
<img width="1466" height="553" alt="Screenshot 2026-05-27 at 14 41 14" src="https://github.com/user-attachments/assets/d3f5c918-dc97-4a16-9c78-e92e84446ad9" />


- After Fix:
<img width="1274" height="1063" alt="Screenshot 2026-05-27 at 14 40 54" src="https://github.com/user-attachments/assets/120a1686-1af4-49e9-b948-821e43a48286" />

