### PR TITLE
Docs: Updated Amazon Managed Prometheus docs

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -54,6 +54,11 @@
     "zizmor",
     "maputil",
     "unsafeHttpWhitelist",
-    "yarnrc"
+    "yarnrc",
+    "alertname",
+    "alertstate",
+    "curlimages",
+    "jsonencode",
+    "topk"
   ]
 }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,8 @@
+.ONESHELL:
+.DELETE_ON_ERROR:
+export SHELL     := bash
+export SHELLOPTS := pipefail:errexit
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rule
+
+include docs.mk

--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -1,0 +1,115 @@
+# The source of this file is https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk.
+# A changelog is included in the head of the `make-docs` script.
+include variables.mk
+-include variables.mk.local
+
+.ONESHELL:
+.DELETE_ON_ERROR:
+export SHELL     := bash
+export SHELLOPTS := pipefail:errexit
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rule
+
+.DEFAULT_GOAL: help
+
+# Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
+.PHONY: help
+help: ## Display this help.
+help:
+	@awk 'BEGIN { \
+		FS = ": ##"; \
+		printf "Usage:\n  make <target>\n\nTargets:\n" \
+	} \
+	/^[a-zA-Z0-9_\.\-\/%]+: ##/ { printf "  %-15s %s\n", $$1, $$2 }' \
+	$(MAKEFILE_LIST)
+
+GIT_ROOT := $(shell git rev-parse --show-toplevel)
+
+PODMAN := $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
+
+ifeq ($(PROJECTS),)
+$(error "PROJECTS variable must be defined in variables.mk")
+endif
+
+# Host port to publish container port to.
+ifeq ($(origin DOCS_HOST_PORT), undefined)
+export DOCS_HOST_PORT := 3002
+endif
+
+# Container image used to perform Hugo build.
+ifeq ($(origin DOCS_IMAGE), undefined)
+export DOCS_IMAGE := grafana/docs-base:latest
+endif
+
+# Container image used for Vale linting.
+ifeq ($(origin VALE_IMAGE), undefined)
+export VALE_IMAGE := grafana/vale:latest
+endif
+
+# PATH-like list of directories within which to find projects.
+# If all projects are checked out into the same directory, ~/repos/ for example, then the default should work.
+ifeq ($(origin REPOS_PATH), undefined)
+export REPOS_PATH := $(realpath $(GIT_ROOT)/..)
+endif
+
+# How to treat Hugo relref errors.
+ifeq ($(origin HUGO_REFLINKSERRORLEVEL), undefined)
+export HUGO_REFLINKSERRORLEVEL := WARNING
+endif
+
+# Whether to pull the latest container image before running the container.
+ifeq ($(origin PULL), undefined)
+export PULL := true
+endif
+
+.PHONY: docs-rm
+docs-rm: ## Remove the docs container.
+	$(PODMAN) rm -f $(DOCS_CONTAINER)
+
+.PHONY: docs-pull
+docs-pull: ## Pull documentation base image.
+	$(PODMAN) pull -q $(DOCS_IMAGE)
+
+make-docs: ## Fetch the latest make-docs script.
+make-docs:
+	if [[ ! -f "$(CURDIR)/make-docs" ]]; then
+		echo 'WARN: No make-docs script found in the working directory. Run `make update` to download it.' >&2
+		exit 1
+	fi
+
+.PHONY: docs
+docs: ## Serve documentation locally, which includes pulling the latest `DOCS_IMAGE` (default: `grafana/docs-base:latest`) container image. To not pull the image, set `PULL=false`.
+ifeq ($(PULL), true)
+docs: docs-pull make-docs
+else
+docs: make-docs
+endif
+	$(CURDIR)/make-docs $(PROJECTS)
+
+.PHONY: docs-debug
+docs-debug: ## Run Hugo web server with debugging enabled. TODO: support all SERVER_FLAGS defined in website Makefile.
+docs-debug: make-docs
+	WEBSITE_EXEC='hugo server --bind 0.0.0.0 --port 3002 --debug' $(CURDIR)/make-docs $(PROJECTS)
+
+.PHONY: vale
+vale: ## Run vale on the entire docs folder which includes pulling the latest `VALE_IMAGE` (default: `grafana/vale:latest`) container image. To not pull the image, set `PULL=false`.
+vale: make-docs
+ifeq ($(PULL), true)
+	$(PODMAN) pull -q $(VALE_IMAGE)
+endif
+	DOCS_IMAGE=$(VALE_IMAGE) $(CURDIR)/make-docs $(PROJECTS)
+
+.PHONY: update
+update: ## Fetch the latest version of this Makefile and the `make-docs` script from Writers' Toolkit.
+	curl -s -LO https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
+	curl -s -LO https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs
+	chmod +x make-docs
+
+# ls static/templates/ | sed 's/-template\.md//' | xargs
+TOPIC_TYPES := concept multiple-tasks reference section task tutorial visualization
+.PHONY: $(patsubst %,topic/%,$(TOPIC_TYPES))
+topic/%: ## Create a topic from the Writers' Toolkit template. Specify the topic type as the target, for example, `make topic/task TOPIC_PATH=sources/my-new-topic.md`.
+$(patsubst %,topic/%,$(TOPIC_TYPES)):
+	$(if $(TOPIC_PATH),,$(error "You must set the TOPIC_PATH variable to the path where the $(@F) topic will be created. For example: make $(@) TOPIC_PATH=sources/my-new-topic.md"))
+	mkdir -p $(dir $(TOPIC_PATH))
+	curl -s -o $(TOPIC_PATH) https://raw.githubusercontent.com/grafana/writers-toolkit/refs/heads/main/docs/static/templates/$(@F)-template.md

--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -89,7 +89,7 @@ endif
 .PHONY: docs-debug
 docs-debug: ## Run Hugo web server with debugging enabled. TODO: support all SERVER_FLAGS defined in website Makefile.
 docs-debug: make-docs
-	WEBSITE_EXEC='hugo server --bind 0.0.0.0 --port 3002 --debug' $(CURDIR)/make-docs $(PROJECTS)
+	WEBSITE_EXEC='hugo server --bind 0.0.0.0 --port 3002 --logLevel debug' $(CURDIR)/make-docs $(PROJECTS)
 
 .PHONY: vale
 vale: ## Run vale on the entire docs folder which includes pulling the latest `VALE_IMAGE` (default: `grafana/vale:latest`) container image. To not pull the image, set `PULL=false`.

--- a/docs/make-docs
+++ b/docs/make-docs
@@ -1,0 +1,1011 @@
+#!/bin/sh
+# shellcheck disable=SC2034
+#
+# The source of this file is https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs.
+# # `make-docs` procedure changelog
+#
+# Updates should conform to the guidelines in https://keepachangelog.com/en/1.1.0/.
+# [Semantic versioning](https://semver.org/) is used to help the reader identify the significance of changes.
+# Changes are relevant to this script and the support docs.mk GNU Make interface.
+#
+# ## 10.1.1 (2026-03-17)
+#
+# ### Fixed
+#
+# - Run Vale non-interactively to enable Claude Code (and similar) to run the tool.
+#
+# ## 10.1.0 (2025-11-11)
+#
+# ### Fixed
+#
+# - Extend readiness probes to prevent confusing output.
+#
+#   Before, the probes could fail too soon and long an error message which contradicted the service starting up.
+#
+# ## 10.0.0 (2025-10-13)
+#
+# ### Changed
+#
+# - Hugo no longer supports the `--debug` option, use `--logLevel debug` instead.
+#
+#   Thank you to @karlskewes for their contribution!
+#
+# ## 9.0.0 (2025-04-05)
+#
+# ### Removed
+#
+# - doc-validator target and associated scripts.
+#
+#   Most useful rules have been migrated to Vale and the others are often false positives.
+#
+# ## 8.5.2 (2025-02-28)
+#
+# ### Fixed
+#
+# - topic/<KIND> targets are no longer no-ops as a result of 8.5.1.
+#
+# ## 8.5.1 (2025-02-18)
+#
+# ### Fixed
+#
+# - PHONY declaration for topic/<KIND> targets.
+#
+# ## 8.5.0 (2025-02-13)
+#
+# ### Added
+#
+# - make topic/<KIND> TOPIC_PATH=<PATH> target to create a new topic from the Writers' Toolkit templates.
+#
+# ## 8.4.0 (2025-01-27)
+#
+# ### Fixed
+#
+# - Correct mount for the /docs/grafana-cloud/send-data/fleet-management/ project.
+#
+# ## 8.3.0 (2024-12-27)
+#
+# ### Added
+#
+# - Debug output of the final command when DEBUG=true.
+#
+#   Useful to inspect if the script is correctly constructing the final command.
+#
+# ## 8.2.0 (2024-12-22)
+#
+# ### Removed
+#
+# - Special cases for Oracle and Datadog plugins now that they exist in the plugins monorepo.
+#
+# ## 8.1.0 (2024-08-22)
+#
+# ### Added
+#
+# - Additional website mounts for projects that use the website repository.
+#
+#   Mounts are required for `make docs` to work in the website repository or with the website project.
+#   The Makefile is also mounted for convenient development of the procedure in that repository.
+#
+# ## 8.0.1 (2024-07-01)
+#
+# ### Fixed
+#
+# - Update log suppression to catch new format of website /docs/ homepage REF_NOT_FOUND warnings.
+#
+#   These warnings are related to missing some pages during the build that are required for the /docs/ homepage.
+#   They were previously suppressed but the log format changed and without this change they reappear in the latest builds.
+#
+# ## 8.0.0 (2024-05-28)
+#
+# ### Changed
+#
+# - Add environment variable `OUTPUT_FORMAT` to control the output of commands.
+#
+#   The default value is `human` and means the output format is human readable.
+#   The value `json` is also supported and outputs JSON.
+#
+#   Note that the `json` format isn't supported by `make docs`, only `make doc-validator` and `make vale`.
+#
+# ## 7.0.0 (2024-05-03)
+#
+# ### Changed
+#
+# - Pull images for all recipes that use containers by default.
+#
+#   Use the `PULL=false` variable to disable this behavior.
+#
+# ### Removed
+#
+# - The `docs-no-pull` target as it's redundant with the new `PULL=false` variable.
+#
+# ## 6.1.0 (2024-04-22)
+#
+# ### Changed
+#
+# - Mount volumes with SELinux labels.
+#
+#   https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
+#
+# ### Added
+#
+# - Pseudo project for including only website resources and no website content.
+#
+#   Facilitates testing shortcodes and layout changes with a small documentation set instead of Grafana Cloud or the entire website.
+#
+# ## 6.0.1 (2024-02-28)
+#
+# ### Added
+#
+# - Suppress new errors relating to absent content introduced in https://github.com/grafana/website/pull/17561.
+#
+# ## 6.0.0 (2024-02-16)
+#
+# ### Changed
+#
+# - Require `jq` for human readable `make doc-validator` output.
+#
+# ## 5.4.0 (2024-02-12)
+#
+# ### Changed
+#
+# - Set `WEBSITE_MOUNTS=true` when a user includes the `website` project.
+#
+#   Ensures consistent behavior across repositories.
+#   To disable website mounts, add `export WEBSITE_MOUNTS := false` to your `variables.mk` or `variables.mk.local` file.
+# - Use website mounts and container volumes also when a user includes the `grafana-cloud` project.
+#
+# ## 5.3.0 (2024-02-08)
+#
+# ### Changed
+#
+# - Updated support for plugins monorepo now that multiple projects have been moved into it.
+# - Use `printf` instead of `echo` for better portability of output.
+#
+#   https://www.in-ulm.de/~mascheck/various/echo+printf/
+#
+# ## 5.2.0 (2024-01-18)
+#
+# ### Changed
+#
+# - Updated `make vale` to use latest Vale style and configuration.
+# - Updated `make vale` to use platform appropriate image.
+#
+# ## 5.1.2 (2023-11-08)
+#
+# ### Added
+#
+# - Hide manual_mount warning messages from non-debug output.
+#   Set the DEBUG environment variable to see all hidden messages.
+#
+# ## 5.1.1 (2023-10-30)
+#
+# ### Added
+#
+# - Support for Datadog and Oracle data source plugins repositories.
+#
+# ## 5.1.0 (2023-10-20)
+#
+# ### Added
+#
+# - Support for the plugins monorepo.
+#
+# ## 5.0.0 (2023-10-18)
+#
+# ### Added
+#
+# - Improved support for website repository.
+#
+#   Mount more content and provide some feedback to users that the build can take time.
+#
+# - Ability to enter the `grafana/docs-base` container with a shell using the `ENTER` environment variable.
+#
+# ### Fixed
+#
+# - Correct key combination for interrupting the process.
+#
+#   Keyboards use capital letters so this more accurately reflects the exact key combination users are expected to press.
+#
+# ### Removed
+#
+# - Imperfect implementation of container name.
+#
+#   Facilitates running `make vale` and `make docs` at once.
+#   Container names are convenient for recognition in `docker ps` but the current implementation has more downsides than upsides.
+#
+# - Forced platform specification now that multiple architecture images exist.
+#
+#  Significantly speeds up build times on larger repositories.
+#
+# ## 4.2.2 (2023-10-05)
+
+# - Added support for Jira data source and MongoDB data source plugins repositories.
+#
+# ## 4.2.1 (2023-09-13)
+
+# ## Fixed
+#
+# - Improved consistency of the webserver request loop by polling the Hugo port rather than the proxy port.
+#
+# ## 4.2.0 (2023-09-01)
+#
+# ### Added
+#
+# - Retry the initial webserver request up to ten times to allow for the process to start.
+#   If it is still failing after ten seconds, an error message is logged.
+#
+# ## 4.1.1 (2023-07-20)
+#
+# ### Fixed
+#
+# - Replaced use of `realpath` with POSIX compatible alternative to determine default value for REPOS_PATH.
+#
+# ## 4.1.0 (2023-06-16)
+#
+# ### Added
+#
+# - Mounts of `layouts` and `config` directories for the `website` project.
+#   Ensures that local changes to mounts or shortcodes are reflected in the development server.
+#
+# ### Fixed
+#
+# - Version inference for versioned docs pages.
+#   Pages in versioned projects now have the `versioned: true` front matter set to ensure that "version" in $.Page.Scratch is set on builds.
+#
+# ## 4.0.0 (2023-06-06)
+#
+# ### Removed
+#
+# - `doc-validator/%` target.
+#   The behavior of the target was not as described.
+#   Instead, to limit `doc-validator` to only specific files, refer to https://grafana.com/docs/writers-toolkit/writing-guide/tooling-and-workflows/validate-technical-documentation/#run-on-specific-files.
+#
+# ## 3.0.0 (2023-05-18)
+#
+# ### Fixed
+#
+# - Compatibility with the updated Make targets in the `website` repository.
+#   `docs` now runs this script itself, `server-docs` builds the site with the `docs` Hugo environment.
+#
+# ## 2.0.0 (2023-05-18)
+#
+# ### Added
+#
+# - Support for the grafana-cloud/frontend-observability/faro-web-sdk project.
+# - Use of `doc-validator` v2.0.x which includes breaking changes to command line options.
+#
+# ### Fixed
+#
+# - Source grafana-cloud project from website repository.
+#
+# ### Added
+#
+# - Support for running the Vale linter with `make vale`.
+#
+# ## 1.2.1 (2023-05-05)
+#
+# ### Fixed
+#
+# - Use `latest` tag of `grafana/vale` image by default instead of hardcoded older version.
+# - Fix mounting multiple projects broken by the changes in 1.0.1
+#
+# ## 1.2.0 (2023-05-05)
+#
+# ### Added
+#
+# - Support for running the Vale linter with `make vale`.
+#
+# ### Fixed
+#
+# ## 1.1.0 (2023-05-05)
+#
+# ### Added
+#
+# - Rewrite error output so it can be followed by text editors.
+#
+# ### Fixed
+#
+# - Fix `docs-debug` container process port.
+#
+# ## 1.0.1 (2023-05-04)
+#
+# ### Fixed
+#
+# - Ensure complete section hierarchy so that all projects have a visible menu.
+#
+# ## 1.0.0 (2023-05-04)
+#
+# ### Added
+#
+# - Build multiple projects simultaneously if all projects are checked out locally.
+# - Run [`doc-validator`](https://github.com/grafana/technical-documentation/tree/main/tools/cmd/doc-validator) over projects.
+# - Redirect project root to mounted version.
+#   For example redirect `/docs/grafana/` to `/docs/grafana/latest/`.
+# - Support for Podman or Docker containers with `PODMAN` environment variable.
+# - Support for projects:
+#   - agent
+#   - enterprise-logs
+#   - enterprise-metrics
+#   - enterprise-traces
+#   - grafana
+#   - grafana-cloud
+#   - grafana-cloud/machine-learning
+#   - helm-charts/mimir-distributed
+#   - helm-charts/tempo-distributed
+#   - incident
+#   - loki
+#   - mimir
+#   - oncall
+#   - opentelemetry
+#   - phlare
+#   - plugins
+#   - slo
+#   - tempo
+#   - writers-toolkit
+
+
+set -ef
+
+readonly DOCS_HOST_PORT="${DOCS_HOST_PORT:-3002}"
+readonly DOCS_IMAGE="${DOCS_IMAGE:-grafana/docs-base:latest}"
+
+readonly DOC_VALIDATOR_INCLUDE="${DOC_VALIDATOR_INCLUDE:-.+\.md$}"
+readonly DOC_VALIDATOR_SKIP_CHECKS="${DOC_VALIDATOR_SKIP_CHECKS:-^image-}"
+
+readonly HUGO_REFLINKSERRORLEVEL="${HUGO_REFLINKSERRORLEVEL:-WARNING}"
+readonly VALE_MINALERTLEVEL="${VALE_MINALERTLEVEL:-error}"
+readonly WEBSITE_EXEC="${WEBSITE_EXEC:-make server-docs}"
+
+readonly OUTPUT_FORMAT="${OUTPUT_FORMAT:-human}"
+
+PODMAN="$(if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)"
+
+if ! command -v curl >/dev/null 2>&1; then
+  if ! command -v wget >/dev/null 2>&1; then
+    # shellcheck disable=SC2016
+    errr 'either `curl` or `wget` must be installed for this script to work.'
+
+    exit 1
+  fi
+fi
+
+if ! command -v "${PODMAN}" >/dev/null 2>&1; then
+  # shellcheck disable=SC2016
+  errr 'either `podman` or `docker` must be installed for this script to work.'
+
+  exit 1
+fi
+
+
+about() {
+  cat <<EOF
+Test documentation locally with multiple source repositories.
+
+The REPOS_PATH environment variable is a colon (:) separated list of paths in which to look for project repositories.
+EOF
+}
+
+usage() {
+  cat <<EOF
+Usage:
+  REPOS_PATH=<PATH[:<PATH>...]> $0 [<PROJECT>[:<VERSION>[:<REPO>[:<DIR>]]]...]
+
+Examples:
+  REPOS_PATH=~/ext/grafana/ $0 writers-toolkit tempo:latest helm-charts/mimir-distributed:latest:mimir:docs/sources/mimir-distributed
+EOF
+}
+
+if [ $# -lt 1 ]; then
+  cat <<EOF >&2
+ERRR: arguments required but not supplied.
+
+$(about)
+
+$(usage)
+EOF
+  exit 1
+fi
+
+readonly REPOS_PATH="${REPOS_PATH:-$(cd "$(git rev-parse --show-toplevel)/.." && echo "${PWD}")}"
+
+if [ -z "${REPOS_PATH}" ]; then
+  cat <<EOF >&2
+ERRR: REPOS_PATH environment variable is required but has not been provided.
+
+$(usage)
+EOF
+  exit 1
+fi
+
+# The following variables comprise a pseudo associative array of project names to source repositories.
+# You only need to set a SOURCES variable if the project name does not match the source repository name.
+# You can get a key identifier using the `identifier` function.
+# To look up the value of any pseudo associative array, use the `aget` function.
+SOURCES_as_code='as-code-docs'
+SOURCES_enterprise_metrics='backend-enterprise'
+SOURCES_enterprise_metrics_='backend-enterprise'
+SOURCES_grafana_cloud='website'
+SOURCES_grafana_cloud_alerting_and_irm_machine_learning='machine-learning'
+SOURCES_grafana_cloud_alerting_and_irm_slo='slo'
+SOURCES_grafana_cloud_k6='k6-docs'
+SOURCES_grafana_cloud_data_configuration_integrations='cloud-onboarding'
+SOURCES_grafana_cloud_frontend_observability_faro_web_sdk='faro-web-sdk'
+SOURCES_grafana_cloud_send_data_fleet_management='fleet-management'
+SOURCES_helm_charts_mimir_distributed='mimir'
+SOURCES_helm_charts_tempo_distributed='tempo'
+SOURCES_opentelemetry='opentelemetry-docs'
+SOURCES_resources='website'
+
+# The following variables comprise a pseudo associative array of project names to versions.
+# You only need to set a VERSIONS variable if it is not the default of 'latest'.
+# You can get a key identifier using the `identifier` function.
+# To look up the value of any pseudo associative array, use the `aget` function.
+VERSIONS_as_code='UNVERSIONED'
+VERSIONS_grafana_cloud='UNVERSIONED'
+VERSIONS_grafana_cloud_alerting_and_irm_machine_learning='UNVERSIONED'
+VERSIONS_grafana_cloud_alerting_and_irm_slo='UNVERSIONED'
+VERSIONS_grafana_cloud_k6='UNVERSIONED'
+VERSIONS_grafana_cloud_data_configuration_integrations='UNVERSIONED'
+VERSIONS_grafana_cloud_frontend_observability_faro_web_sdk='UNVERSIONED'
+VERSIONS_grafana_cloud_send_data_fleet_management='UNVERSIONED'
+VERSIONS_opentelemetry='UNVERSIONED'
+VERSIONS_resources='UNVERSIONED'
+VERSIONS_technical_documentation='UNVERSIONED'
+VERSIONS_website='UNVERSIONED'
+VERSIONS_writers_toolkit='UNVERSIONED'
+
+# The following variables comprise a pseudo associative array of project names to source repository paths.
+# You only need to set a PATHS variable if it is not the default of 'docs/sources'.
+# You can get a key identifier using the `identifier` function.
+# To look up the value of any pseudo associative array, use the `aget` function.
+PATHS_grafana_cloud='content/docs/grafana-cloud'
+PATHS_helm_charts_mimir_distributed='docs/sources/helm-charts/mimir-distributed'
+PATHS_helm_charts_tempo_distributed='docs/sources/helm-charts/tempo-distributed'
+PATHS_mimir='docs/sources/mimir'
+PATHS_resources='content'
+PATHS_tempo='docs/sources/tempo'
+PATHS_website='content'
+
+# identifier STR
+# Replace characters that are not valid in an identifier with underscores.
+identifier() {
+  echo "$1" | tr -C '[:alnum:]_\n' '_'
+}
+
+# aget ARRAY KEY
+# Get the value of KEY from associative array ARRAY.
+# Characters that are not valid in an identifier are replaced with underscores.
+aget() {
+  eval echo '$'"$(identifier "$1")_$(identifier "$2")"
+}
+
+# src returns the project source repository name for a project.
+src() {
+  _project="$1"
+
+  case "${_project}" in
+    plugins/*)
+      if [ -z "$(aget SOURCES "${_project}")" ]; then
+        echo plugins-private
+      else
+        aget SOURCES "${_project}"
+      fi
+      ;;
+    *)
+      if [ -z "$(aget SOURCES "${_project}")" ]; then
+        echo "${_project}"
+      else
+        aget SOURCES "${_project}"
+      fi
+      ;;
+  esac
+
+  unset _project
+}
+
+# path returns the relative path within the repository that contain the docs for a project.
+path() {
+  _project="$1"
+
+  case "${_project}" in
+    plugins/*)
+      if [ -z "$(aget PATHS "${_project}")" ]; then
+        echo "${_project}/docs/sources"
+      else
+        aget PATHS "${_project}"
+      fi
+      ;;
+    *)
+      if [ -z "$(aget PATHS "${_project}")" ]; then
+        echo "docs/sources"
+      else
+        aget PATHS "${_project}"
+      fi
+  esac
+
+  unset _project
+}
+
+# version returns the version for a project. Unversioned projects return the special value 'UNVERSIONED'.
+version() {
+  _project="$1"
+
+  case "${_project}" in
+    plugins/*)
+      if [ -z "$(aget VERSIONS "${_project}")" ]; then
+        echo "UNVERSIONED"
+      else
+        aget VERSIONS "${_project}"
+      fi
+      ;;
+    *)
+    if [ -z "$(aget VERSIONS "${_project}")" ]; then
+      echo latest
+    else
+      aget VERSIONS "${_project}"
+    fi
+  esac
+
+  unset _project
+}
+
+
+# new_proj populates a new project structure.
+new_proj() {
+  _project="$1"
+  _version="$2"
+  _repo="$3"
+  _path="$4"
+
+  # If version is not set, use the script mapping of project to default versions if it exists.
+  # Fallback to 'latest'.
+  if [ -z "${_version}" ]; then
+    _version="$(version "${_project}")"
+  fi
+
+  # If repo is not set, use the script mapping of project to repo name if it exists.
+  # Fallback to using the project name.
+  if [ -z "${_repo}" ]; then
+    _repo="$(src "${_project}")"
+  fi
+
+  # If path is not set, use the script mapping of project to docs sources path if it exists.
+  # Fallback to using 'docs/sources'.
+  if [ -z "${_path}" ]; then
+    _path="$(path "${_project}")"
+  fi
+
+  echo "${_project}:${_version}:${_repo}:${_path}"
+  unset _project _version _repo _path
+}
+
+# proj_url returns the webserver URL for a project.
+# It expects a complete project structure as input.
+proj_url() {
+  IFS=: read -r _project _version _ _ <<POSIX_HERESTRING
+$1
+POSIX_HERESTRING
+
+  if [ "${_project}" = website ]; then
+    echo "http://localhost:${DOCS_HOST_PORT}/docs/"
+
+    unset _project _version
+    return
+  fi
+
+  if [ -z "${_version}" ] || [ "${_version}" = 'UNVERSIONED' ]; then
+    echo "http://localhost:${DOCS_HOST_PORT}/docs/${_project}/"
+  else
+    echo "http://localhost:${DOCS_HOST_PORT}/docs/${_project}/${_version}/"
+  fi
+
+  unset _project _version
+}
+
+# proj_ver returns the version for a project.
+# It expects a complete project structure as input.
+proj_ver() {
+  IFS=: read -r _ _ver _ _ <<POSIX_HERESTRING
+$1
+POSIX_HERESTRING
+
+  echo "${_ver}"
+  unset _ver
+}
+
+# proj_dst returns the container path to content source for a project.
+# It expects a complete project structure as input.
+proj_dst() {
+  IFS=: read -r _project _version _ _ <<POSIX_HERESTRING
+$1
+POSIX_HERESTRING
+
+  if [ "${_project}" = website ]; then
+    echo '/hugo/content'
+
+    unset _project _version
+    return
+  fi
+
+  if [ -z "${_version}" ] || [ "${_version}" = 'UNVERSIONED' ]; then
+    echo "/hugo/content/docs/${_project}"
+  else
+    echo "/hugo/content/docs/${_project}/${_version}"
+  fi
+
+  unset _project _version
+}
+
+# repo_path returns the host path to the project repository.
+# It looks for the provided repository name in each of the paths specified in the REPOS_PATH environment variable.
+repo_path() {
+  _repo="$1"
+  IFS=:
+  for lookup in ${REPOS_PATH}; do
+    if [ -d "${lookup}/${_repo}" ]; then
+      echo "${lookup}/${_repo}"
+      unset _path _repo
+      return
+    fi
+  done
+  unset IFS
+
+  errr "could not find project '${_repo}' in any of the paths in REPOS_PATH '${REPOS_PATH}'."
+  note "you must have a checkout of the project '${_repo}' at '${REPOS_PATH##:*}/${_repo}'."
+  note "if you have cloned the repository into a directory with a different name, consider changing it to ${_repo}."
+
+  unset _repo
+  exit 1
+}
+
+# proj_src returns the host path to content source for a project.
+# It expects a complete project structure as input.
+# It looks for the provided repository name in each of the paths specified in the REPOS_PATH environment variable.
+proj_src() {
+  IFS=: read -r _ _ _repo _path <<POSIX_HERESTRING
+$1
+POSIX_HERESTRING
+
+  _repo="$(repo_path "${_repo}")"
+  echo "${_repo}/${_path}"
+
+  unset _path _repo
+}
+
+# proj_canonical returns the canonical absolute path partial URI for a project.
+# It expects a complete project structure as input.
+proj_canonical() {
+  IFS=: read -r _project _version _ _ <<POSIX_HERESTRING
+$1
+POSIX_HERESTRING
+
+  if [ "${_project}" = website ]; then
+    echo '/docs'
+
+    unset _project _version
+    return
+  fi
+
+  if [ -z "${_version}" ] || [ "${_version}" = 'UNVERSIONED' ]; then
+    echo "/docs/${_project}"
+  else
+    echo "/docs/${_project}/${_version}"
+  fi
+
+  unset _project _version
+}
+
+proj_to_url_src_dst_ver() {
+  _url="$(proj_url "$1")"
+  _src="$(proj_src "$1")"
+  _dst="$(proj_dst "$1")"
+  _ver="$(proj_ver "$1")"
+
+  echo "${_url}^${_src}^${_dst}^${_ver}"
+  unset _url _src _dst _ver
+}
+
+url_src_dst_vers() {
+  for arg in "$@"; do
+    IFS=: read -r _project _version _repo _path <<POSIX_HERESTRING
+$arg
+POSIX_HERESTRING
+
+    case "${_project}" in
+      # Workaround for arbitrary mounts where the version field is expected to be the local directory
+     # and the repo field is expected to be the container directory.
+      arbitrary)
+        echo "${_project}^${_version}^${_repo}^" # TODO
+        ;;
+      logs)
+        proj_to_url_src_dst_ver "$(new_proj loki "${_version}")"
+        proj_to_url_src_dst_ver "$(new_proj enterprise-logs "${_version}")"
+        ;;
+      metrics)
+        proj_to_url_src_dst_ver "$(new_proj mimir "${_version}")"
+        proj_to_url_src_dst_ver "$(new_proj helm-charts/mimir-distributed "${_version}")"
+        proj_to_url_src_dst_ver "$(new_proj enterprise-metrics "${_version}")"
+        ;;
+      resources)
+        _repo="$(repo_path website)"
+        echo "arbitrary^${_repo}/config^/hugo/config" "arbitrary^${_repo}/layouts^/hugo/layouts" "arbitrary^${_repo}/scripts^/hugo/scripts"
+        unset _repo
+        ;;
+      traces)
+        proj_to_url_src_dst_ver "$(new_proj tempo "${_version}")"
+        proj_to_url_src_dst_ver "$(new_proj enterprise-traces "${_version}")"
+        ;;
+      *)
+        proj_to_url_src_dst_ver "$(new_proj "${_project}" "${_version}" "${_repo}" "${_path}")"
+        ;;
+    esac
+  done
+
+  unset _project _version _repo _path
+}
+
+await_build() {
+  url="$1"
+  req="$(if command -v curl >/dev/null 2>&1; then echo 'curl -s -o /dev/null'; else echo 'wget -q'; fi)"
+
+  # Initial delay to allow container to start before beginning healthchecks
+  sleep 3
+
+  # Fast retries for initial startup (10 attempts, 1 second apart)
+  i=1
+  max=10
+  while [ "${i}" -ne "${max}" ]
+  do
+    sleep 1
+    debg "Retrying request to web server assuming the process is still starting up."
+    i=$((i + 1))
+
+    if ${req} "${url}"; then
+      printf '\r\nView documentation locally:\r\n'
+      for x in ${url_src_dst_vers}; do
+        IFS='^' read -r url _ _ <<POSIX_HERESTRING
+$x
+POSIX_HERESTRING
+
+        if [ -n "${url}" ]; then
+          if [ "${url}" != arbitrary ]; then
+            printf '\r  %s\r\n' "${url}"
+          fi
+        fi
+      done
+      printf '\r\nPress Ctrl+C to stop the server\r\n'
+
+      unset i max req url
+      return
+    fi
+  done
+
+  # Continue checking with longer intervals for slower builds
+  # This prevents false positives for large builds that take longer to start
+  i=1
+  max=20
+  while [ "${i}" -ne "${max}" ]
+  do
+    sleep 2
+    debg "Continuing to check web server (build may be taking longer than expected)."
+    i=$((i + 1))
+
+    if ${req} "${url}"; then
+      printf '\r\nView documentation locally:\r\n'
+      for x in ${url_src_dst_vers}; do
+        IFS='^' read -r url _ _ <<POSIX_HERESTRING
+$x
+POSIX_HERESTRING
+
+        if [ -n "${url}" ]; then
+          if [ "${url}" != arbitrary ]; then
+            printf '\r  %s\r\n' "${url}"
+          fi
+        fi
+      done
+      printf '\r\nPress Ctrl+C to stop the server\r\n'
+
+      unset i max req url
+      return
+    fi
+  done
+
+  # Only log error after extended checking period (total ~60 seconds)
+  printf '\r\n'
+  errr 'The build was interrupted or a build error occurred, check the previous logs for possible causes.'
+  note 'You might need to use Ctrl+C to end the process.'
+
+  unset i max req url
+}
+
+debg() {
+  if [ -n "${DEBUG}" ]; then
+    printf 'DEBG: %s\r\n' "$1" >&2
+  fi
+}
+
+errr() {
+  printf 'ERRR: %s\r\n' "$1" >&2
+}
+
+note() {
+  printf 'NOTE: %s\r\n' "$1" >&2
+}
+
+url_src_dst_vers="$(url_src_dst_vers "$@")"
+
+volumes=""
+redirects=""
+
+for arg in "$@"; do
+  IFS=: read -r _project _ _repo _ <<POSIX_HERESTRING
+${arg}
+POSIX_HERESTRING
+  if [ "${_project}" = website ] || [ "${_project}" = grafana-cloud ]; then
+    note "Please be patient, building the website can take some time."
+
+      # If set, the docs-base image will run a prebuild script that sets up Hugo mounts.
+    if [ "${WEBSITE_MOUNTS}" = false ]; then
+      unset WEBSITE_MOUNTS
+    else
+      readonly WEBSITE_MOUNTS=true
+    fi
+
+    _repo="$(repo_path website)"
+    volumes="--volume=${_repo}/config:/hugo/config:z"
+    volumes="${volumes} --volume=${_repo}/content/guides:/hugo/content/guides:z"
+    volumes="${volumes} --volume=${_repo}/content/whats-new:/hugo/content/whats-new:z"
+    volumes="${volumes} --volume=${_repo}/Makefile:/hugo/Makefile:z"
+    volumes="${volumes} --volume=${_repo}/layouts:/hugo/layouts:z"
+    volumes="${volumes} --volume=${_repo}/scripts:/hugo/scripts:z"
+  fi
+  unset _project _repo
+done
+
+for x in ${url_src_dst_vers}; do
+  IFS='^' read -r _url _src _dst _ver <<POSIX_HERESTRING
+$x
+POSIX_HERESTRING
+
+  if [ "${_url}" != arbitrary ]; then
+    if [ ! -f "${_src}/_index.md" ]; then
+      errr "Index file '${_src}/_index.md' does not exist."
+      note "Is '${_src}' the correct source directory?"
+      exit 1
+    fi
+  fi
+
+  debg "Mounting '${_src}' at container path '${_dst}'"
+
+  if [ -z "${volumes}" ]; then
+    volumes="--volume=${_src}:${_dst}:z"
+  else
+    volumes="${volumes} --volume=${_src}:${_dst}:z"
+  fi
+
+  if [ -n "${_ver}" ] && [ "${_ver}" != 'UNVERSIONED' ]; then
+    if [ -z "${redirects}" ]; then
+      redirects="${_dst}^${_ver}"
+    else
+      redirects="${redirects} ${_dst}^${_ver}"
+    fi
+  fi
+  unset _url _src _dst _ver
+done
+
+IFS=':' read -r image _ <<POSIX_HERESTRING
+${DOCS_IMAGE}
+POSIX_HERESTRING
+
+case "${image}" in
+  'grafana/vale')
+    proj="$(new_proj "$1")"
+    printf '\r\n'
+    IFS='' read -r cmd <<EOF
+    ${PODMAN} run \
+                --init \
+                --rm \
+                --workdir /etc/vale \
+                --tty \
+                ${volumes} \
+                ${DOCS_IMAGE} \
+                --minAlertLevel=${VALE_MINALERTLEVEL} \
+                --glob=*.md \
+                /hugo/content/docs
+EOF
+
+    if [ -n "${DEBUG}" ]; then
+      debg "${cmd}"
+    fi
+
+    case "${OUTPUT_FORMAT}" in
+      human)
+        ${cmd} --output=line \
+        | sed "s#$(proj_dst "${proj}")#sources#"
+      ;;
+      json)
+        ${cmd} --output=/etc/vale/rdjsonl.tmpl \
+        | sed "s#$(proj_dst "${proj}")#sources#"
+      ;;
+      *)
+        errr "Invalid output format '${OUTPUT_FORMAT}'"
+    esac
+
+    ;;
+  *)
+    tempfile="$(mktemp -t make-docs.XXX)"
+    cat <<EOF >"${tempfile}"
+#!/usr/bin/env bash
+
+tc() {
+  set \${*,,}
+  echo \${*^}
+}
+
+for redirect in ${redirects}; do
+  IFS='^' read -r path ver <<<"\${redirect}"
+  echo -e "---\\nredirectURL: \"\${path/\/hugo\/content/}\"\\ntype: redirect\\nversioned: true\\n---\\n" > "\${path/\${ver}/_index.md}"
+done
+
+for x in "${url_src_dst_vers}"; do
+  IFS='^' read -r _ _ dst _ <<<"\${x}"
+
+  title="\${dst%/*}"
+  title="\$(tc \${title##*/})"
+  while [[ -n "\${dst}" ]]; do
+    if [[ ! -f "\${dst}/_index.md" ]]; then
+        echo -e "---title: \${title}\\n---\\n\\n# \${title}\\n\\n{{< section >}}" > "\${dst}/_index.md"
+    fi
+    dst="\${dst%/*}"
+  done
+done
+
+if [[ -n "${WEBSITE_MOUNTS}" ]]; then
+  unset WEBSITE_SKIP_MOUNTS
+fi
+
+${WEBSITE_EXEC}
+EOF
+    chmod +x "${tempfile}"
+    volumes="${volumes} --volume=${tempfile}:/entrypoint:z"
+    readonly volumes
+
+    IFS='' read -r cmd <<EOF
+${PODMAN} run \
+  --env=HUGO_REFLINKSERRORLEVEL=${HUGO_REFLINKSERRORLEVEL} \
+  --init \
+  --interactive \
+  --publish=${DOCS_HOST_PORT}:3002 \
+  --publish=3003:3003 \
+  --rm \
+  --tty \
+  ${volumes} \
+  ${DOCS_IMAGE}
+EOF
+
+    if [ -n "${ENTER}" ]; then
+      ${cmd} /bin/bash
+    elif [ -n "${DEBUG}" ]; then
+      await_build http://localhost:3003 &
+
+      debg "${cmd} /entrypoint"
+      ${cmd} /entrypoint
+    else
+      await_build http://localhost:3003 &
+
+      ${cmd} /entrypoint  2>&1\
+        | sed -u \
+              -e '/Web Server is available at http:\/\/localhost:3003\/ (bind address 0.0.0.0)/ d' \
+              -e '/^hugo server/ d' \
+              -e '/fatal: not a git repository (or any parent up to mount point \/)/ d' \
+              -e '/Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)./ d' \
+              -e "/Makefile:[0-9]*: warning: overriding recipe for target 'docs'/ d" \
+              -e "/docs.mk:[0-9]*: warning: ignoring old recipe for target 'docs'/ d" \
+              -e '/\/usr\/bin\/make -j 2 proxy hserver-docs HUGO_PORT=3003/ d' \
+              -e '/website-proxy/ d' \
+              -e '/rm -rf dist*/ d' \
+              -e '/Press Ctrl+C to stop/ d' \
+              -e '/make/ d' \
+              -e '/WARNING: The manual_mount source directory/ d' \
+              -e '/"docs\/_index.md" not found/d'
+    fi
+    ;;
+esac

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,38 +1,120 @@
-# Amazon Managed Service for Prometheus Data Source
+---
+aliases:
+  - ../data-sources/aws-prometheus/
+  - ../data-sources/amazon-prometheus/
+description: Use the Amazon Managed Service for Prometheus data source to query and visualize Prometheus-compatible metrics from AWS in Grafana.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - managed prometheus
+  - sigv4
+  - metrics
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Amazon Managed Service for Prometheus
+title: Amazon Managed Service for Prometheus data source
+weight: 10
+review_date: 2026-06-08
+---
 
-This data source plugin is for the Amazon Managed Service for Prometheus. It has all the features of the Grafana core Prometheus plugin with Amazon specific authentication in the configuration page.
+# Amazon Managed Service for Prometheus data source
 
-Amazon Managed Service for Prometheus is a Prometheus-compatible service that monitors and provides alerts on containerized applications and infrastructure at scale.
+The Amazon Managed Service for Prometheus data source plugin lets you query and visualize metrics from [Amazon Managed Service for Prometheus](https://aws.amazon.com/prometheus/) in Grafana. Amazon Managed Service for Prometheus (AMP) is a Prometheus-compatible, fully managed service that monitors and provides alerts on containerized applications and infrastructure at scale.
 
-Read more about it here:
+This plugin includes all the features of the core Grafana Prometheus data source, with AWS-specific Signature Version 4 (SigV4) authentication built into the configuration page.
 
-[https://aws.amazon.com/prometheus/](https://aws.amazon.com/prometheus/)
+## Supported features
 
+The following table lists the features that the Amazon Managed Service for Prometheus data source supports.
+
+| Feature | Supported |
+|---------|-----------|
+| Metrics | Yes |
+| Logs | No |
+| Traces | No |
+| Alerting | Yes |
+| Annotations | Yes |
+| Exemplars | Yes |
+
+## Requirements
+
+Before you use the Amazon Managed Service for Prometheus data source, ensure you have the following:
+
+- A supported version of Grafana. This plugin requires Grafana `>=11.6.11 <12`, `>=12.0.10 <12.1`, `>=12.1.7 <12.2`, or `>=12.2.5`. If you run Grafana 11.4.x or earlier, use plugin version 1.0.5.
+- An Amazon Managed Service for Prometheus workspace and its query endpoint URL.
+- AWS credentials or an IAM role with permission to query the workspace.
+
+## Get started
+
+The following topics help you get started with the data source:
+
+- [Configure the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/)
+- [Amazon Managed Service for Prometheus query editor](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/query-editor/)
+- [Template variables](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/template-variables/)
+- [Annotations](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/annotations/)
+- [Alerting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/alerting/)
+- [Troubleshooting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/troubleshooting/)
+
+To install the plugin and add the data source:
+
+1. [Install the plugin](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/#install-grafana-plugins).
+1. [Add a new data source in the UI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/#add-a-data-source) or [provision one](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
+1. [Configure the data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
+1. Start querying your metrics.
 
 ## Migrate from core Prometheus to Amazon Managed Service for Prometheus
 
-If you are using core Prometheus with SigV4 authentication, you must migrate to the Amazon Managed Service for Prometheus data source because SigV4 auth is deprecated in core Prometheus. This topic summarizes the steps required to migrate from core Prometheus to Amazon Managed Service for Prometheus. See a detailed list of steps [here](src/README.md).
+If you use the core Prometheus data source with SigV4 authentication, migrate to the Amazon Managed Service for Prometheus data source. SigV4 authentication is deprecated in the core Prometheus data source.
 
-- Get the `UID` for Prometheus using SigV4.
-- Get the `UID` for your new Amazon Managed Service for Prometheus.
-- Update dashboards with the new datasource `UID`.
-- Update alert rules by exporting provisioning files and updating the data source in the model or create new alert rules.
-- Recreate correlations.
-- Recreate recorded queries.
+To migrate from core Prometheus to Amazon Managed Service for Prometheus:
 
-## Getting started
+1. Get the `UID` of your existing Prometheus data source that uses SigV4.
+1. Get the `UID` of your new Amazon Managed Service for Prometheus data source.
+1. Update dashboards to use the new data source `UID`.
+1. Update alert rules. Export the provisioning files and update the data source in the model, or create new alert rules.
+1. Recreate any correlations.
+1. Recreate any recorded queries.
 
-1. [Install the plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-grafana-plugins)
-1. [Add a new data source with the UI](https://grafana.com/docs/grafana/latest/datasources/#add-a-data-source) or [provision one](https://grafana.com/docs/grafana/latest/administration/provisioning/)
-1. [Configure the data source](#configuring-the-data-source)
-1. Start making queries
+## Pre-built dashboards
 
-## Configuring the data source
+The plugin includes the following pre-built dashboards that you can import to monitor Prometheus and Grafana itself:
 
-### Authentication
+- **Prometheus Stats**
+- **Prometheus 2.0 Stats**
+- **Grafana Stats**
 
-Depending on the environment in which it is run, Grafana supports different authentication providers such as keys, a credentials file, or using the "Default" provider from AWS which supports using service-based IAM roles. These providers can be manually enabled/disabled with the `allowed_auth_providers` field in Grafana's config file. To read more about supported authentication providers refer to [the AWS authentication section](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/aws-authentication/#select-an-authentication-method)
+To import a pre-built dashboard:
 
-### Plugin repository
+1. Click **Connections** in the left-side menu.
+1. Under **Connections**, click **Data sources**.
+1. Select your Amazon Managed Service for Prometheus data source.
+1. Click the **Dashboards** tab.
+1. Click **Import** next to the dashboard you want to use.
 
-You can request new features, report issues, or contribute code directly through the [Grafana Amazon Prometheus Data Source Github repository](https://github.com/grafana/grafana-amazonprometheus-datasource)
+## Additional features
+
+After you configure the data source, you can:
+
+- Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to query data without building a dashboard.
+- Add [transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/) to manipulate query results.
+- Set up [alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) rules.
+
+## Plugin updates
+
+Always ensure that your plugin version is up-to-date so you have access to all current features and improvements. Navigate to **Plugins and data** > **Plugins** to check for updates. Grafana recommends upgrading to the latest Grafana version, and this applies to plugins as well.
+
+{{< admonition type="note" >}}
+Plugins are automatically updated in Grafana Cloud.
+{{< /admonition >}}
+
+## Related resources
+
+- [Amazon Managed Service for Prometheus documentation](https://docs.aws.amazon.com/prometheus/)
+- [Grafana community forum](https://community.grafana.com/)
+- [Grafana Amazon Prometheus data source GitHub repository](https://github.com/grafana/grafana-amazonprometheus-datasource)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -54,6 +54,7 @@ Before you use the Amazon Managed Service for Prometheus data source, ensure you
 
 The following topics help you get started with the data source:
 
+- [Install the Amazon Managed Service for Prometheus plugin](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/install/)
 - [Configure the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/)
 - [Amazon Managed Service for Prometheus query editor](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/query-editor/)
 - [Template variables](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/template-variables/)
@@ -63,7 +64,7 @@ The following topics help you get started with the data source:
 
 To install the plugin and add the data source:
 
-1. [Install the plugin](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/#install-grafana-plugins).
+1. [Install the plugin](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/install/).
 1. [Add a new data source in the UI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/#add-a-data-source) or [provision one](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
 1. [Configure the data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
 1. Start querying your metrics.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -71,9 +71,13 @@ To install the plugin and add the data source:
 
 ## Migrate from core Prometheus to Amazon Managed Service for Prometheus
 
-If you use the core Prometheus data source with SigV4 authentication, migrate to the Amazon Managed Service for Prometheus data source. SigV4 authentication is deprecated in the core Prometheus data source.
+SigV4 authentication is deprecated in the core Prometheus data source. If you use the core Prometheus data source with SigV4 authentication, migrate to the Amazon Managed Service for Prometheus data source.
 
-To migrate from core Prometheus to Amazon Managed Service for Prometheus:
+In Grafana 13, this migration is automatic. Data sources that use SigV4 authentication are migrated to the Amazon Managed Service for Prometheus plugin on startup, and your dashboards, alerts, and queries continue to work without changes. For migration steps, how to check migration status, and rollback instructions, refer to [Migrate from Prometheus SigV4 to Amazon Managed Service for Prometheus](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure/aws-authentication/).
+
+### Update dashboards and alerts
+
+If you add a new Amazon Managed Service for Prometheus data source instead of relying on the automatic migration, update your existing dashboards and alert rules to use the new data source:
 
 1. Get the `UID` of your existing Prometheus data source that uses SigV4.
 1. Get the `UID` of your new Amazon Managed Service for Prometheus data source.

--- a/docs/sources/alerting.md
+++ b/docs/sources/alerting.md
@@ -63,7 +63,7 @@ The data source manages two kinds of rules:
 
 To manage these rules from Grafana, enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). When enabled, the rules appear in the Grafana Alerting UI, where you can view and edit them.
 
-The data source reaches the workspace ruler through the `/api/v1/rules` and `/config/v1/rules` paths under the **Prometheus server URL** you configure, so you don't need to set a separate ruler URL. If the rules fail to load with an **Unable to fetch alert rules** error, refer to [Troubleshooting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/troubleshooting/).
+The data source reaches the workspace ruler through the `/rules` and `/config/v1/rules` paths under the **Prometheus server URL** you configure, so you don't need to set a separate ruler URL. If the rules fail to load with an **Unable to fetch alert rules** error, refer to [Troubleshooting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/troubleshooting/).
 
 Managing rules in the workspace requires AWS credentials with the appropriate `aps` rule-management permissions, such as `aps:ListRuleGroupsNamespaces`, `aps:DescribeRuleGroupsNamespace`, `aps:CreateRuleGroupsNamespace`, `aps:PutRuleGroupsNamespace`, and `aps:DeleteRuleGroupsNamespace`.
 

--- a/docs/sources/alerting.md
+++ b/docs/sources/alerting.md
@@ -63,6 +63,8 @@ The data source manages two kinds of rules:
 
 To manage these rules from Grafana, enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). When enabled, the rules appear in the Grafana Alerting UI, where you can view and edit them.
 
+The data source reaches the workspace ruler through the `/api/v1/rules` and `/config/v1/rules` paths under the **Prometheus server URL** you configure, so you don't need to set a separate ruler URL. If the rules fail to load with an **Unable to fetch alert rules** error, refer to [Troubleshooting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/troubleshooting/).
+
 Managing rules in the workspace requires AWS credentials with the appropriate `aps` rule-management permissions, such as `aps:ListRuleGroupsNamespaces`, `aps:DescribeRuleGroupsNamespace`, `aps:CreateRuleGroupsNamespace`, `aps:PutRuleGroupsNamespace`, and `aps:DeleteRuleGroupsNamespace`.
 
 {{< admonition type="note" >}}

--- a/docs/sources/alerting.md
+++ b/docs/sources/alerting.md
@@ -39,15 +39,35 @@ The data source supports two complementary alerting approaches.
 
 ### Grafana-managed alert rules
 
-Grafana-managed alert rules run in Grafana and can query your Amazon Managed Service for Prometheus workspace as their data source. Grafana evaluates the rule, manages its state, and routes notifications. Use this approach when you want a single alerting experience across all your data sources.
+Grafana-managed alert rules run in Grafana and can query your Amazon Managed Service for Prometheus workspace as their data source. Grafana evaluates the rule, manages its state, and routes notifications. Use this approach when you want a single alerting experience across all your data sources, including expressions, images in notifications, and multi-data-source rules.
 
 To create a Grafana-managed alert rule, refer to [Configure Grafana-managed alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/).
 
+For example, to alert when the rate of HTTP 5xx errors exceeds five percent over the last five minutes, use a query such as:
+
+```promql
+sum(rate(http_requests_total{status=~"5.."}[5m]))
+/
+sum(rate(http_requests_total[5m]))
+> 0.05
+```
+
 ### Data-source-managed rules
 
-The data source can also read and write the recording and alerting rules stored in your workspace. To manage these rules from Grafana, enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). When enabled, the rules appear in the Grafana Alerting UI, where you can view and edit them.
+The data source can also read and write the recording and alerting rules stored in your workspace. These rules are evaluated by Amazon Managed Service for Prometheus itself, not by Grafana. Use this approach when you want your rules to run close to the data and remain available independently of Grafana.
 
-Writing rules to the workspace requires AWS credentials with the appropriate `aps` rule-management permissions, such as `aps:PutRuleGroupsNamespace`, `aps:ListRuleGroupsNamespaces`, and `aps:DescribeRuleGroupsNamespace`.
+The data source manages two kinds of rules:
+
+- **Recording rules:** Pre-compute frequently used or expensive expressions and store the results as new time series for faster queries.
+- **Alerting rules:** Evaluate a condition and send alerts to the workspace's alert manager when the condition holds.
+
+To manage these rules from Grafana, enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). When enabled, the rules appear in the Grafana Alerting UI, where you can view and edit them.
+
+Managing rules in the workspace requires AWS credentials with the appropriate `aps` rule-management permissions, such as `aps:ListRuleGroupsNamespaces`, `aps:DescribeRuleGroupsNamespace`, `aps:CreateRuleGroupsNamespace`, `aps:PutRuleGroupsNamespace`, and `aps:DeleteRuleGroupsNamespace`.
+
+{{< admonition type="note" >}}
+Data-source-managed rules require a rule groups namespace in your Amazon Managed Service for Prometheus workspace. For more information, refer to the [Amazon Managed Service for Prometheus recording rules documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-rules.html).
+{{< /admonition >}}
 
 ## Next steps
 

--- a/docs/sources/alerting.md
+++ b/docs/sources/alerting.md
@@ -1,0 +1,55 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/alerting/
+  - ../data-sources/amazon-prometheus/alerting/
+description: Set up alerting with the Amazon Managed Service for Prometheus data source, including Grafana-managed and data-source-managed rules.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - alerting
+  - recording rules
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Alerting
+title: Amazon Managed Service for Prometheus alerting
+weight: 450
+review_date: 2026-06-08
+---
+
+# Amazon Managed Service for Prometheus alerting
+
+The Amazon Managed Service for Prometheus data source works with Grafana Alerting. You can create Grafana-managed alert rules that query your workspace, and you can manage alerting and recording rules stored in the workspace from the Grafana Alerting UI.
+
+## Before you begin
+
+Before you set up alerting, ensure you have:
+
+- [Configured the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
+- AWS credentials with permission to read and, if you manage rules from Grafana, write rules in the workspace.
+
+## Alerting approaches
+
+The data source supports two complementary alerting approaches.
+
+### Grafana-managed alert rules
+
+Grafana-managed alert rules run in Grafana and can query your Amazon Managed Service for Prometheus workspace as their data source. Grafana evaluates the rule, manages its state, and routes notifications. Use this approach when you want a single alerting experience across all your data sources.
+
+To create a Grafana-managed alert rule, refer to [Configure Grafana-managed alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/).
+
+### Data-source-managed rules
+
+The data source can also read and write the recording and alerting rules stored in your workspace. To manage these rules from Grafana, enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). When enabled, the rules appear in the Grafana Alerting UI, where you can view and edit them.
+
+Writing rules to the workspace requires AWS credentials with the appropriate `aps` rule-management permissions, such as `aps:PutRuleGroupsNamespace`, `aps:ListRuleGroupsNamespaces`, and `aps:DescribeRuleGroupsNamespace`.
+
+## Next steps
+
+- [Configure the data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/)
+- [Grafana Alerting documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/)

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -54,11 +54,36 @@ Use the following options to control how Grafana builds each annotation from the
 | **Title** | A template for the annotation title. Reference labels with the `{{label_name}}` syntax. |
 | **Tags** | A template for the annotation tags, populated from series labels. |
 | **Text** | A template for the annotation description. Reference labels with the `{{label_name}}` syntax. |
+| **Series value as timestamp** | When enabled, Grafana interprets the series value as a Unix timestamp in seconds and places the annotation at that time instead of at the data point's own time. |
 
-For example, to create an annotation each time a Prometheus alert fires, query the built-in `ALERTS` metric:
+## Annotation query examples
+
+The following examples show common annotation queries. After you enter a query, use the **Title**, **Text**, and **Tags** fields to format each marker from the series labels.
+
+To create an annotation each time a Prometheus alert fires, query the built-in `ALERTS` metric:
 
 ```promql
 ALERTS{alertstate="firing"}
 ```
 
-Then set the **Title** to `{{alertname}}` and the **Text** to `{{alertstate}}` so each marker shows the alert name and state.
+Set the **Title** to `{{alertname}}` and the **Text** to `{{alertstate}}` so each marker shows the alert name and state.
+
+To mark when a monitored target goes down, query for targets that report as down:
+
+```promql
+up == 0
+```
+
+Set the **Title** to `{{job}} down` and add `{{instance}}` to the **Tags** field.
+
+To mark host reboots, query for changes in the node boot time within each step:
+
+```promql
+changes(node_boot_time_seconds[$__interval]) > 0
+```
+
+To place annotations from a metric that stores an event time as its value, such as a deployment timestamp, enable **Series value as timestamp**:
+
+```promql
+deployment_timestamp_seconds
+```

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -1,0 +1,64 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/annotations/
+  - ../data-sources/amazon-prometheus/annotations/
+description: Use the Amazon Managed Service for Prometheus data source to add annotations to Grafana dashboards from PromQL queries.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - annotations
+  - promql
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Annotations
+title: Amazon Managed Service for Prometheus annotations
+weight: 400
+review_date: 2026-06-08
+---
+
+# Amazon Managed Service for Prometheus annotations
+
+Annotations overlay event markers on dashboard graphs so you can correlate metrics with events such as deployments or incidents. The Amazon Managed Service for Prometheus data source supports annotations driven by PromQL queries, the same as the core Grafana Prometheus data source.
+
+## Before you begin
+
+Before you add annotations, ensure you have:
+
+- [Configured the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
+- A metric in your workspace that marks the events you want to annotate, such as `ALERTS` or a custom event metric.
+
+## Add an annotation query
+
+To add an annotation query to a dashboard:
+
+1. Navigate to **Dashboard settings** > **Annotations**.
+1. Click **Add annotation query**.
+1. Enter a name for the annotation.
+1. Select the Amazon Managed Service for Prometheus data source.
+1. Enter a PromQL query in the code query field. Any series the query returns becomes an annotation marker.
+1. Configure the field mappings, then click **Apply**.
+
+## Map query results to annotation fields
+
+Use the following options to control how Grafana builds each annotation from the query results.
+
+| Field | Description |
+|-------|-------------|
+| **Min step** | The lower bound for the query step, which controls how often Grafana samples the series. |
+| **Title** | A template for the annotation title. Reference labels with the `{{label_name}}` syntax. |
+| **Tags** | A template for the annotation tags, populated from series labels. |
+| **Text** | A template for the annotation description. Reference labels with the `{{label_name}}` syntax. |
+
+For example, to create an annotation each time a Prometheus alert fires, query the built-in `ALERTS` metric:
+
+```promql
+ALERTS{alertstate="firing"}
+```
+
+Then set the **Title** to `{{alertname}}` and the **Text** to `{{alertstate}}` so each marker shows the alert name and state.

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -1,0 +1,179 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/configure/
+  - ../data-sources/amazon-prometheus/configure/
+description: Configure the Amazon Managed Service for Prometheus data source in Grafana, including AWS SigV4 authentication and provisioning.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - sigv4
+  - authentication
+  - configuration
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Configure
+title: Configure the Amazon Managed Service for Prometheus data source
+weight: 100
+review_date: 2026-06-08
+---
+
+# Configure the Amazon Managed Service for Prometheus data source
+
+This document explains how to configure the Amazon Managed Service for Prometheus data source and covers AWS SigV4 authentication, data source settings, and provisioning.
+
+## Before you begin
+
+Before you configure the data source, ensure you have:
+
+- **Grafana permissions:** The organization administrator role to add and configure data sources.
+- **An Amazon Managed Service for Prometheus workspace:** Including its query endpoint URL, which ends in `/api/v1/query`.
+- **AWS credentials:** An IAM identity or role with permission to query the workspace, such as `aps:QueryMetrics`, `aps:GetLabels`, `aps:GetSeries`, and `aps:GetMetricMetadata`.
+
+## Key concepts
+
+If you're new to Amazon Managed Service for Prometheus or AWS authentication, these terms are used throughout the configuration:
+
+| Term | Description |
+|------|-------------|
+| **Workspace** | A logical, isolated Amazon Managed Service for Prometheus environment that ingests, stores, and queries your Prometheus metrics. |
+| **SigV4** | AWS Signature Version 4, the process AWS uses to authenticate and sign API requests with your credentials. |
+| **IAM policy** | A JSON document attached to an identity that grants AWS API permissions, such as querying a workspace. |
+| **Assume role** | An AWS mechanism that lets one identity take on temporary credentials for another role, often used for cross-account access. |
+| **External ID** | An optional identifier added to a role's trust policy to protect against the confused-deputy problem when assuming a role. |
+| **Default region** | The AWS region where your workspace is located. SigV4 uses this region to sign requests. |
+
+## Add the data source
+
+To add the data source:
+
+1. Click **Connections** in the left-side menu.
+1. Click **Add new connection**.
+1. Type `Amazon Managed Service for Prometheus` in the search bar.
+1. Select **Amazon Managed Service for Prometheus**.
+1. Click **Add new data source**.
+
+## Configure settings
+
+Use the following settings to identify the data source and set its endpoint.
+
+| Setting | Description |
+|---------|-------------|
+| **Name** | The name used to refer to the data source in panels and queries. |
+| **Default** | Toggle to make this the default data source for new panels. |
+| **Prometheus server URL** | The query endpoint URL of your Amazon Managed Service for Prometheus workspace, for example `https://aps-workspaces.<REGION>.amazonaws.com/workspaces/<WORKSPACE_ID>`. |
+
+{{< admonition type="note" >}}
+Browser (direct) access mode isn't available in this data source. Use server (proxy) access mode, which Grafana selects by default.
+{{< /admonition >}}
+
+## Authentication
+
+The Amazon Managed Service for Prometheus data source authenticates with AWS SigV4. Unlike the core Prometheus data source, SigV4 is the only authentication method, and Grafana signs every request to the workspace.
+
+### SigV4 authentication
+
+Select an authentication provider in the **Authentication Provider** drop-down, then complete the fields for the provider you choose.
+
+| Authentication provider | Description |
+|-------------------------|-------------|
+| **AWS SDK Default** | Uses the credential chain of the environment that runs Grafana, such as environment variables, a shared credentials file, or an attached IAM role. Recommended when Grafana runs in AWS. |
+| **Access & secret key** | Uses an access key ID and secret access key that you enter directly. |
+| **Credentials file** | Uses a named profile from the AWS shared credentials file on the Grafana server. |
+| **EC2 IAM role** | Uses the IAM role attached to the EC2 instance that runs Grafana. |
+| **Grafana Assume Role** | Lets Grafana Cloud assume a role in your AWS account without sharing long-lived keys. Available in Grafana Cloud. |
+
+Depending on the provider you select, configure the following fields:
+
+| Setting | Description |
+|---------|-------------|
+| **Access Key ID** | The AWS access key ID. Required for the **Access & secret key** provider. |
+| **Secret Access Key** | The AWS secret access key. Required for the **Access & secret key** provider. |
+| **Credentials Profile Name** | The named profile to use from the shared credentials file. Used with the **Credentials file** provider. |
+| **Assume Role ARN** | The Amazon Resource Name (ARN) of a role for Grafana to assume before signing requests. Optional. |
+| **External ID** | The external ID required by the assumed role's trust policy. Use with **Assume Role ARN**. |
+| **Endpoint** | A custom endpoint for the AWS API. Leave empty to use the default endpoint for the selected region. |
+| **Default Region** | The AWS region of your workspace. SigV4 uses this region to sign requests. |
+| **Service** | The AWS service to sign requests against. Defaults to `aps` for Amazon Managed Service for Prometheus. Change this only if AWS instructs you to use a different service name. |
+
+## Additional settings
+
+Expand **Advanced settings** to configure optional behavior. These settings are shared with the core Prometheus data source.
+
+| Setting | Description |
+|---------|-------------|
+| **Manage alerts via Alerting UI** | When enabled, lets you manage recording and alerting rules stored in the workspace from the Grafana Alerting UI. |
+| **Scrape interval** | Sets the interval Grafana uses to align queries. Set this to match the scrape interval configured in Prometheus. The default is `15s`. |
+| **Query timeout** | The maximum time Grafana waits for a query to return. The default is `60s`. |
+| **Default editor** | Sets the default query editor mode, either **Builder** or **Code**. |
+| **Disable metric lookup** | Disables the metric and label autocomplete and the metrics browser to reduce load on large workspaces. |
+| **Cache level** | Controls how aggressively Grafana caches metadata responses. Options are `Low`, `Medium`, `High`, and `None`. |
+| **Incremental querying** | When enabled, Grafana caches query results and requests only new data on dashboard refreshes. |
+| **Query overlap window** | When incremental querying is enabled, the amount of overlapping time to re-request to avoid gaps, for example `10m`. |
+| **Disable recording rules** | Prevents Grafana from querying for and processing recording rules. |
+| **Custom query parameters** | Appends custom URL parameters to all queries, such as `max_source_resolution=5m`. |
+| **HTTP method** | The HTTP method Grafana uses for queries. `POST` is recommended and is the default. |
+
+## Verify the connection
+
+To verify the connection, click **Save & test**. When the configuration is valid, Grafana displays a success message such as **Successfully queried the Prometheus API.** If the test fails, refer to [Troubleshooting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/troubleshooting/).
+
+## Provision the data source
+
+You can define the data source in YAML files as part of Grafana's provisioning system. For more information, refer to [Provisioning Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
+
+The following example provisions the data source with the **Access & secret key** provider:
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Amazon Managed Service for Prometheus
+    uid: grafana-amazonprometheus
+    type: grafana-amazonprometheus-datasource
+    access: proxy
+    url: https://aps-workspaces.<REGION>.amazonaws.com/workspaces/<WORKSPACE_ID>
+    editable: true
+    jsonData:
+      httpMethod: POST
+      sigV4Auth: true
+      sigV4AuthType: keys
+      sigV4Region: <REGION>
+      sigv4Service: aps
+      defaultEditor: builder
+      manageAlerts: true
+    secureJsonData:
+      sigV4AccessKey: <ACCESS_KEY_ID>
+      sigV4SecretKey: <SECRET_ACCESS_KEY>
+```
+
+When you use the **Grafana Assume Role** or an assume-role configuration, set `sigV4AuthType` to `default` or `ec2_iam_role` as appropriate, and provide `assumeRoleArn` and `externalId` instead of the access keys:
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Amazon Managed Service for Prometheus
+    type: grafana-amazonprometheus-datasource
+    access: proxy
+    url: https://aps-workspaces.<REGION>.amazonaws.com/workspaces/<WORKSPACE_ID>
+    jsonData:
+      sigV4Auth: true
+      sigV4AuthType: default
+      sigV4Region: <REGION>
+      sigv4Service: aps
+      assumeRoleArn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+      externalId: <EXTERNAL_ID>
+```
+
+Replace the placeholder values:
+
+- `<REGION>`: The AWS region of your workspace, for example `us-east-1`.
+- `<WORKSPACE_ID>`: The ID of your Amazon Managed Service for Prometheus workspace.
+- `<ACCESS_KEY_ID>` and `<SECRET_ACCESS_KEY>`: AWS credentials for the **Access & secret key** provider.
+- `<ACCOUNT_ID>`, `<ROLE_NAME>`, and `<EXTERNAL_ID>`: The values for the role you want Grafana to assume.

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -76,6 +76,10 @@ Browser (direct) access mode isn't available in this data source. Use server (pr
 
 The Amazon Managed Service for Prometheus data source authenticates with AWS SigV4. Unlike the core Prometheus data source, SigV4 is the only authentication method, and Grafana signs every request to the workspace.
 
+{{< admonition type="note" >}}
+If the **SigV4 auth** option is missing from the authentication drop-down in Grafana Cloud, contact [Grafana Support](https://grafana.com/help/) to enable SigV4 authentication for your instance.
+{{< /admonition >}}
+
 ### SigV4 authentication
 
 Select an authentication provider in the **Authentication Provider** drop-down, then complete the fields for the provider you choose.
@@ -102,6 +106,20 @@ Depending on the provider you select, configure the following fields:
 | **Endpoint** | A custom endpoint for the AWS API. Leave empty to use the default endpoint for the selected region. |
 | **Default Region** | The AWS region of your workspace. SigV4 uses this region to sign requests. |
 | **Service** | The AWS service to sign requests against. Defaults to `aps` for Amazon Managed Service for Prometheus. Change this only if AWS instructs you to use a different service name. |
+
+## Private data source connect
+
+The data source supports [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/), which lets Grafana Cloud query an Amazon Managed Service for Prometheus workspace that isn't exposed to the public internet, such as a workspace reached through a VPC endpoint.
+
+To use PDC with this data source:
+
+1. Set up a PDC connection. Refer to [Configure Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/).
+1. On the data source configuration page, expand **Secure Socks Proxy** and select the PDC connection.
+1. Click **Save & test** to verify connectivity through the private network.
+
+{{< admonition type="note" >}}
+The **Secure Socks Proxy** settings appear only when the secure SOCKS data source proxy is enabled on your Grafana instance. PDC is available in Grafana Cloud.
+{{< /admonition >}}
 
 ## Additional settings
 

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -125,6 +125,10 @@ To verify the connection, click **Save & test**. When the configuration is valid
 
 ## Provision the data source
 
+You can define and configure the data source in code so it's reproducible across environments. This section covers provisioning with a Grafana YAML file and with Terraform.
+
+### Provision with a YAML file
+
 You can define the data source in YAML files as part of Grafana's provisioning system. For more information, refer to [Provisioning Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
 
 The following example provisions the data source with the **Access & secret key** provider:
@@ -177,3 +181,73 @@ Replace the placeholder values:
 - `<WORKSPACE_ID>`: The ID of your Amazon Managed Service for Prometheus workspace.
 - `<ACCESS_KEY_ID>` and `<SECRET_ACCESS_KEY>`: AWS credentials for the **Access & secret key** provider.
 - `<ACCOUNT_ID>`, `<ROLE_NAME>`, and `<EXTERNAL_ID>`: The values for the role you want Grafana to assume.
+
+### Provision with Terraform
+
+You can manage the data source with the [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs) using the `grafana_data_source` resource. Store secrets such as AWS keys in Terraform variables or a secrets manager rather than in plain text.
+
+The following example provisions the data source with the **Access & secret key** provider:
+
+```hcl
+resource "grafana_data_source" "amazonprometheus" {
+  type = "grafana-amazonprometheus-datasource"
+  name = "Amazon Managed Service for Prometheus"
+  url  = "https://aps-workspaces.${var.region}.amazonaws.com/workspaces/${var.workspace_id}"
+
+  json_data_encoded = jsonencode({
+    httpMethod    = "POST"
+    sigV4Auth     = true
+    sigV4AuthType = "keys"
+    sigV4Region   = var.region
+    sigv4Service  = "aps"
+    defaultEditor = "builder"
+    manageAlerts  = true
+  })
+
+  secure_json_data_encoded = jsonencode({
+    sigV4AccessKey = var.access_key_id
+    sigV4SecretKey = var.secret_access_key
+  })
+}
+```
+
+To use an assume-role configuration instead of static keys, set `sigV4AuthType` to `default` or `ec2_iam_role` and provide the role details:
+
+```hcl
+resource "grafana_data_source" "amazonprometheus" {
+  type = "grafana-amazonprometheus-datasource"
+  name = "Amazon Managed Service for Prometheus"
+  url  = "https://aps-workspaces.${var.region}.amazonaws.com/workspaces/${var.workspace_id}"
+
+  json_data_encoded = jsonencode({
+    sigV4Auth     = true
+    sigV4AuthType = "default"
+    sigV4Region   = var.region
+    sigv4Service  = "aps"
+    assumeRoleArn = var.assume_role_arn
+    externalId    = var.external_id
+  })
+}
+```
+
+Define the referenced variables, for example in a `variables.tf` file:
+
+```hcl
+variable "region" {
+  type = string
+}
+
+variable "workspace_id" {
+  type = string
+}
+
+variable "access_key_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "secret_access_key" {
+  type      = string
+  sensitive = true
+}
+```

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -88,6 +88,8 @@ Select an authentication provider in the **Authentication Provider** drop-down, 
 | **EC2 IAM role** | Uses the IAM role attached to the EC2 instance that runs Grafana. |
 | **Grafana Assume Role** | Lets Grafana Cloud assume a role in your AWS account without sharing long-lived keys. Available in Grafana Cloud. |
 
+The providers available in the drop-down depend on your Grafana version and the `allowed_auth_providers` setting in the Grafana configuration file.
+
 Depending on the provider you select, configure the following fields:
 
 | Setting | Description |
@@ -156,7 +158,7 @@ datasources:
       sigV4SecretKey: <SECRET_ACCESS_KEY>
 ```
 
-When you use the **Grafana Assume Role** or an assume-role configuration, set `sigV4AuthType` to `default` or `ec2_iam_role` as appropriate, and provide `assumeRoleArn` and `externalId` instead of the access keys:
+To assume an IAM role, set `sigV4AuthType` to the base provider you want to use, such as `default` or `ec2_iam_role`, and add `assumeRoleArn` and `externalId` instead of the access keys. For the **Grafana Assume Role** provider, set `sigV4AuthType` to `grafana_assume_role`:
 
 ```yaml
 apiVersion: 1

--- a/docs/sources/install.md
+++ b/docs/sources/install.md
@@ -1,0 +1,243 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/install/
+  - ../data-sources/amazon-prometheus/install/
+description: Install and upgrade the Amazon Managed Service for Prometheus data source plugin for Grafana.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - data source
+  - install
+  - upgrade
+  - plugin
+  - Kubernetes
+  - Docker
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Installation
+title: Install and upgrade the Amazon Managed Service for Prometheus data source plugin
+weight: 50
+review_date: 2026-06-08
+---
+
+# Install and upgrade the Amazon Managed Service for Prometheus data source plugin
+
+This document covers how to install, upgrade, and verify the Amazon Managed Service for Prometheus data source plugin across different Grafana deployment environments. After the plugin is installed, refer to [Configure the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/) to set up a connection.
+
+## Before you begin
+
+Verify the following requirements before installing:
+
+| Requirement | Details |
+|-------------|---------|
+| **Grafana version** | A supported version of Grafana. For the full supported version list, refer to [Requirements](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/#requirements). |
+| **Network access** | Grafana Cloud instances require internet access to download the plugin from the catalog. Self-managed installs need access to `grafana.com` or a local plugin ZIP. |
+| **AWS access** | An Amazon Managed Service for Prometheus workspace and AWS credentials or an IAM role with permission to query it. |
+
+## Install the plugin
+
+The Amazon Managed Service for Prometheus plugin is a signed plugin available in the Grafana plugin catalog on all Grafana Cloud plans and self-managed Grafana. Choose the installation method that matches your Grafana deployment.
+
+### Grafana Cloud
+
+To install the plugin on Grafana Cloud:
+
+1. In your Grafana Cloud instance, navigate to **Administration** > **Plugins and data** > **Plugins**.
+1. Search for **Amazon Managed Service for Prometheus** and click **Install**.
+
+Plugins are automatically updated on Grafana Cloud, so no further action is required to stay current.
+
+{{< admonition type="note" >}}
+SigV4 authentication must be enabled for your Grafana Cloud instance before you can configure the data source. If the **SigV4 auth** option is missing from the authentication drop-down, contact [Grafana Support](https://grafana.com/help/). For more information, refer to [Troubleshooting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/troubleshooting/).
+{{< /admonition >}}
+
+### Self-managed Grafana (CLI)
+
+Install the plugin with the Grafana CLI:
+
+```bash
+grafana cli plugins install grafana-amazonprometheus-datasource
+```
+
+Restart Grafana after installation:
+
+```bash
+sudo systemctl restart grafana-server
+```
+
+### Docker
+
+Set the `GF_INSTALL_PLUGINS` environment variable:
+
+```yaml
+environment:
+  - GF_INSTALL_PLUGINS=grafana-amazonprometheus-datasource
+```
+
+### Kubernetes (Helm chart)
+
+Add the plugin to your Helm values:
+
+```yaml
+plugins:
+  - grafana-amazonprometheus-datasource
+```
+
+Or use the `GF_INSTALL_PLUGINS` environment variable in your deployment spec:
+
+```yaml
+env:
+  - name: GF_INSTALL_PLUGINS
+    value: "grafana-amazonprometheus-datasource"
+```
+
+### Kubernetes (init container)
+
+If you don't control the Helm chart, for example on a shared platform cluster, use an init container to download the plugin before Grafana starts:
+
+```yaml
+initContainers:
+  - name: install-plugins
+    image: curlimages/curl:latest
+    command:
+      - sh
+      - -c
+      - |
+        curl -sL https://grafana.com/api/plugins/grafana-amazonprometheus-datasource/versions/latest/download \
+          -o /plugins/grafana-amazonprometheus-datasource.zip && \
+        unzip /plugins/grafana-amazonprometheus-datasource.zip -d /plugins/
+    volumeMounts:
+      - name: plugins
+        mountPath: /plugins
+```
+
+Mount the same volume at `/var/lib/grafana/plugins` in the Grafana container.
+
+### Air-gapped (offline) installation
+
+For environments without internet access:
+
+1. Download the plugin ZIP from the [Grafana plugin catalog](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) on a machine with internet access.
+1. Transfer the ZIP to the Grafana server.
+1. Extract the ZIP to the plugins directory:
+
+   ```bash
+   unzip grafana-amazonprometheus-datasource-<version>.linux_amd64.zip -d /var/lib/grafana/plugins/
+   ```
+
+1. Set ownership:
+
+   ```bash
+   chown -R grafana:grafana /var/lib/grafana/plugins/grafana-amazonprometheus-datasource
+   ```
+
+1. Restart Grafana.
+
+If Grafana reports an "unsigned plugin" error, add the following to `grafana.ini`:
+
+```ini
+[plugins]
+allow_loading_unsigned_plugins = grafana-amazonprometheus-datasource
+```
+
+{{< admonition type="caution" >}}
+Only allow unsigned plugins if you trust the source of the ZIP file. Official downloads from grafana.com are signed.
+{{< /admonition >}}
+
+### Verify the installation
+
+After installing, confirm the plugin is loaded:
+
+1. Navigate to **Administration** > **Plugins and data** > **Plugins**.
+1. Search for **Amazon Managed Service for Prometheus** and verify the plugin appears with a status of **Installed**.
+1. Navigate to **Connections** > **Add new connection** and search for **Amazon Managed Service for Prometheus** to confirm it's available as a data source.
+1. If the plugin doesn't appear, check the Grafana server logs for errors and refer to [Troubleshoot installation issues](#troubleshoot-installation-issues).
+
+## Upgrade the plugin
+
+Upgrade steps depend on your Grafana deployment environment.
+
+### Grafana Cloud
+
+Plugins are automatically updated on Grafana Cloud. No manual action is required. If you experience issues after an automatic update, contact [Grafana Support](https://grafana.com/help/).
+
+### Self-managed Grafana
+
+To upgrade a self-managed installation:
+
+1. Update the plugin:
+
+   ```bash
+   grafana cli plugins update grafana-amazonprometheus-datasource
+   ```
+
+1. Restart Grafana.
+1. Verify each data source connection with **Save & test**.
+
+To install a specific version:
+
+```bash
+grafana cli plugins install grafana-amazonprometheus-datasource <version>
+```
+
+For Docker or Kubernetes, append the version to the plugin name:
+
+```yaml
+environment:
+  - GF_INSTALL_PLUGINS=grafana-amazonprometheus-datasource <version>
+```
+
+### Roll back to a previous version
+
+If an upgrade causes issues on a self-managed instance, pin a specific plugin version:
+
+```bash
+grafana cli plugins install grafana-amazonprometheus-datasource 2.4.0
+```
+
+Restart Grafana after the rollback.
+
+{{< admonition type="note" >}}
+Rollback isn't available on Grafana Cloud. If you experience issues after an automatic update, contact [Grafana Support](https://grafana.com/help/).
+{{< /admonition >}}
+
+## Uninstall the plugin
+
+To remove the plugin from a self-managed Grafana instance:
+
+```bash
+grafana cli plugins remove grafana-amazonprometheus-datasource
+```
+
+Restart Grafana after uninstalling. Existing data source configurations are preserved in the Grafana database but become non-functional until the plugin is reinstalled.
+
+For Docker or Kubernetes, remove `grafana-amazonprometheus-datasource` from the `GF_INSTALL_PLUGINS` variable and redeploy.
+
+## Troubleshoot installation issues
+
+The following sections address common installation problems.
+
+### "Plugin not found" or install button missing
+
+This problem usually means your Grafana instance can't reach the plugin catalog.
+
+**Solutions:**
+
+- **Grafana Cloud:** Confirm your instance has finished provisioning and try the search again. If the plugin still doesn't appear, contact [Grafana Support](https://grafana.com/help/).
+- **Self-managed:** Verify the Grafana server has outbound access to `grafana.com`. For environments without internet access, use the [air-gapped installation](#air-gapped-offline-installation) method.
+
+### "Unsigned plugin" error (air-gapped installs)
+
+This error means Grafana installed the plugin from a ZIP file and can't verify its signature.
+
+**Solutions:**
+
+1. Ensure you downloaded the ZIP from the official [Grafana plugin catalog](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/). Official downloads are signed.
+1. If the error persists, add `allow_loading_unsigned_plugins = grafana-amazonprometheus-datasource` to `grafana.ini` under `[plugins]`.
+1. Restart Grafana.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -1,0 +1,131 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/query-editor/
+  - ../data-sources/amazon-prometheus/query-editor/
+description: Use the Amazon Managed Service for Prometheus query editor in Grafana to build PromQL queries with the builder and code modes.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - promql
+  - query editor
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Query editor
+title: Amazon Managed Service for Prometheus query editor
+weight: 200
+review_date: 2026-06-08
+---
+
+# Amazon Managed Service for Prometheus query editor
+
+This document explains how to use the Amazon Managed Service for Prometheus query editor. The query editor is the same as the core Grafana Prometheus query editor and uses PromQL to query your workspace.
+
+## Before you begin
+
+Before you write queries, ensure you have:
+
+- [Configured the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
+- Verified that your AWS credentials have permission to query the workspace.
+
+## Key concepts
+
+If you're new to Prometheus, these terms are used throughout this document:
+
+| Term | Description |
+|------|-------------|
+| **PromQL** | The Prometheus Query Language, used to select and aggregate time series data. |
+| **Instant query** | Returns a single value per series at the end of the time range. |
+| **Range query** | Returns a series of values over the dashboard time range. |
+| **Metrics browser** | A tool in the query editor that helps you search metrics, select labels, and build a selector. |
+
+## Query editor modes
+
+The query editor has two modes that you switch between with the toggle in the upper-right of the editor.
+
+### Builder mode
+
+Builder mode is a visual, guided way to build queries without writing PromQL by hand. Use builder mode to:
+
+- Select a metric from the **Metric** drop-down or open the metrics browser.
+- Add label filters to narrow the result set.
+- Add operations such as `rate`, `sum`, or `histogram_quantile`.
+
+Click **Explain** to display a step-by-step, plain-language description of what the query does.
+
+### Code mode
+
+Code mode lets you write raw PromQL with autocomplete, syntax highlighting, and the metrics browser. Use code mode for complex queries or when you already know PromQL.
+
+To open the metrics browser in code mode, focus the query field and click **Metrics browser**. From there you can search metrics, select labels and label values, validate a selector, and insert it into your query.
+
+## Kickstart your query
+
+Click **Kickstart your query** to choose from a list of query patterns, such as rate or histogram patterns. Grafana inserts the pattern into the editor so you can adapt it to your metrics.
+
+## Query options
+
+Expand **Options** in the query editor to configure how Grafana runs and displays the query.
+
+| Option | Description |
+|--------|-------------|
+| **Legend** | Controls the time series name in the legend. Use **Auto**, **Verbose**, or a **Custom** template such as `{{label_name}}`. |
+| **Format** | Sets the result format: **Time series**, **Table**, or **Heatmap**. |
+| **Type** | Sets the query type: **Range**, **Instant**, or **Both**. |
+| **Min step** | The lower bound for the query step and `$__interval`. Match this to your scrape interval. |
+| **Exemplars** | Toggles whether to show exemplars alongside the query results. |
+
+## Macros
+
+Use macros in your queries to reference the dashboard time range and interval. Grafana replaces the macro with the computed value at query time.
+
+| Macro | Description |
+|-------|-------------|
+| `$__interval` | The interval Grafana calculates from the time range and panel width. |
+| `$__interval_ms` | The interval in milliseconds. |
+| `$__range` | The full dashboard time range, for example `1h`. |
+| `$__range_s` | The dashboard time range in seconds. |
+| `$__range_ms` | The dashboard time range in milliseconds. |
+| `$__rate_interval` | An interval tuned for `rate` functions that's always at least four times the scrape interval. |
+| `$__rate_interval_ms` | The rate interval in milliseconds. |
+
+## Query examples
+
+The following examples show common PromQL queries you can run against your workspace.
+
+Calculate the per-second rate of HTTP requests over the rate interval:
+
+```promql
+rate(http_requests_total[$__rate_interval])
+```
+
+Aggregate CPU usage by instance:
+
+```promql
+sum by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[$__rate_interval]))
+```
+
+Calculate the 95th percentile request latency:
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[$__rate_interval])))
+```
+
+## Use cases
+
+Use cases help you understand what's possible and provide starting points for your own dashboards:
+
+- **Monitor container workloads:** Track CPU, memory, and restart counts for Kubernetes and Amazon ECS workloads that send metrics to your workspace.
+- **Track service-level indicators:** Build error-rate and latency panels from request metrics to power service-level objective dashboards.
+- **Capacity planning:** Aggregate resource usage over long time ranges to spot trends and plan scaling.
+
+## Next steps
+
+- [Use template variables](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/template-variables/)
+- [Add annotations](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/annotations/)
+- [Set up alerting](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/alerting/)

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -96,13 +96,27 @@ Use macros in your queries to reference the dashboard time range and interval. G
 
 ## Query examples
 
-The following examples show common PromQL queries you can run against your workspace.
+The following examples show common PromQL queries you can run against your workspace. Replace the metric and label names with the ones in your workspace.
 
-Calculate the per-second rate of HTTP requests over the rate interval:
+### Rates and throughput
+
+Use the `rate` function with `$__rate_interval` to chart per-second rates from counters.
+
+Calculate the per-second rate of HTTP requests:
 
 ```promql
 rate(http_requests_total[$__rate_interval])
 ```
+
+Calculate total requests per second across all instances of a service:
+
+```promql
+sum(rate(http_requests_total{job="api"}[$__rate_interval]))
+```
+
+### Aggregations
+
+Use aggregation operators such as `sum`, `avg`, and `max` with `by` to group results.
 
 Aggregate CPU usage by instance:
 
@@ -110,10 +124,57 @@ Aggregate CPU usage by instance:
 sum by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[$__rate_interval]))
 ```
 
+Find the top five pods by memory usage:
+
+```promql
+topk(5, sum by (pod) (container_memory_working_set_bytes))
+```
+
+### Error rates and ratios
+
+Divide a filtered rate by a total rate to compute an error percentage.
+
+Calculate the percentage of HTTP 5xx responses:
+
+```promql
+sum(rate(http_requests_total{status=~"5.."}[$__rate_interval]))
+/
+sum(rate(http_requests_total[$__rate_interval]))
+* 100
+```
+
+### Latency percentiles
+
+Use `histogram_quantile` with a `_bucket` metric to chart latency percentiles.
+
 Calculate the 95th percentile request latency:
 
 ```promql
 histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[$__rate_interval])))
+```
+
+### Resource utilization
+
+Combine metrics to express utilization as a percentage.
+
+Calculate memory utilization per node as a percentage:
+
+```promql
+100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+```
+
+Show which targets are currently down:
+
+```promql
+up == 0
+```
+
+### Use a template variable in a query
+
+Reference a [template variable](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/template-variables/) to make a query interactive. For example, filter by a selected `instance` value:
+
+```promql
+rate(node_cpu_seconds_total{instance=~"$instance"}[$__rate_interval])
 ```
 
 ## Use cases

--- a/docs/sources/template-variables.md
+++ b/docs/sources/template-variables.md
@@ -60,21 +60,59 @@ Query variables get their values from your workspace. To create a query variable
 
 ## Query variable functions
 
-The query variable editor supports the following Prometheus functions to populate variable values.
+When you select **Query** as the variable type, the variable editor provides a query type selector with options such as **Label names**, **Label values**, **Metrics**, **Query result**, and **Series query**. Each option maps to one of the following Prometheus functions, which you can also enter directly.
 
 | Function | Description |
 |----------|-------------|
 | `label_names()` | Returns a list of all label names in the workspace. |
 | `label_values(label)` | Returns a list of values for the specified label across all metrics. |
 | `label_values(metric, label)` | Returns a list of values for the specified label on the specified metric. |
-| `metrics(regex)` | Returns a list of metrics that match the regular expression. |
+| `metrics(regex)` | Returns a list of metrics whose names match the regular expression. |
 | `query_result(query)` | Returns the result of a PromQL query, useful for filtering on computed values. |
 
-For example, to populate a variable with every value of the `instance` label on the `node_cpu_seconds_total` metric:
+### Query variable examples
+
+The following examples show how to use each function in a query variable.
+
+Return every label name in the workspace:
+
+```promql
+label_names()
+```
+
+Return all values of the `job` label:
+
+```promql
+label_values(job)
+```
+
+Return the `instance` values that exist on the `node_cpu_seconds_total` metric:
 
 ```promql
 label_values(node_cpu_seconds_total, instance)
 ```
+
+Return all metrics whose names contain `node`:
+
+```promql
+metrics(node)
+```
+
+Use `query_result` to list the instances with high memory usage:
+
+```promql
+query_result(topk(5, sum by (instance) (node_memory_MemTotal_bytes)))
+```
+
+### Chain variables
+
+You can reference one variable in another variable's query to create dependent, or cascading, variables. For example, if you have a `job` variable, create an `instance` variable whose values depend on the selected job:
+
+```promql
+label_values(up{job="$job"}, instance)
+```
+
+When you change the `job` variable, Grafana refreshes the `instance` variable to show only the instances for that job.
 
 ## Use variables in queries
 

--- a/docs/sources/template-variables.md
+++ b/docs/sources/template-variables.md
@@ -1,0 +1,93 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/template-variables/
+  - ../data-sources/amazon-prometheus/template-variables/
+description: Use template variables with the Amazon Managed Service for Prometheus data source to create dynamic, reusable Grafana dashboards.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - template variables
+  - promql
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Template variables
+title: Amazon Managed Service for Prometheus template variables
+weight: 300
+review_date: 2026-06-08
+---
+
+# Amazon Managed Service for Prometheus template variables
+
+Use template variables to create dynamic, reusable dashboards that let you change displayed data without editing queries. The Amazon Managed Service for Prometheus data source supports the same template variable features as the core Grafana Prometheus data source.
+
+## Before you begin
+
+Before you create template variables, ensure you have:
+
+- [Configured the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
+- A basic understanding of [Grafana template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/).
+
+## Supported variable types
+
+The data source supports the following template variable types.
+
+| Variable type | Supported |
+|---------------|-----------|
+| Query | Yes |
+| Custom | Yes |
+| Text box | Yes |
+| Constant | Yes |
+| Data source | Yes |
+| Interval | Yes |
+| Ad hoc filters | Yes |
+
+## Create a query variable
+
+Query variables get their values from your workspace. To create a query variable:
+
+1. Navigate to **Dashboard settings** > **Variables**.
+1. Click **Add variable**.
+1. Select **Query** as the variable type.
+1. Select the Amazon Managed Service for Prometheus data source.
+1. Select a query type and enter the query details.
+1. Click **Apply** to save the variable.
+
+## Query variable functions
+
+The query variable editor supports the following Prometheus functions to populate variable values.
+
+| Function | Description |
+|----------|-------------|
+| `label_names()` | Returns a list of all label names in the workspace. |
+| `label_values(label)` | Returns a list of values for the specified label across all metrics. |
+| `label_values(metric, label)` | Returns a list of values for the specified label on the specified metric. |
+| `metrics(regex)` | Returns a list of metrics that match the regular expression. |
+| `query_result(query)` | Returns the result of a PromQL query, useful for filtering on computed values. |
+
+For example, to populate a variable with every value of the `instance` label on the `node_cpu_seconds_total` metric:
+
+```promql
+label_values(node_cpu_seconds_total, instance)
+```
+
+## Use variables in queries
+
+Reference a variable in a query with the `$variable_name` or `${variable_name}` syntax. For example, if you have a variable named `instance`, filter a query by the selected instance:
+
+```promql
+rate(node_cpu_seconds_total{instance="$instance"}[$__rate_interval])
+```
+
+When a variable allows multiple values, use the regex match operator so the query matches any selected value:
+
+```promql
+rate(node_cpu_seconds_total{instance=~"$instance"}[$__rate_interval])
+```
+
+To use multi-value variables, set the **Multi-value** option on the variable and use the `=~` operator. Grafana formats the selected values as a regular expression alternation, such as `value1|value2`.

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -28,6 +28,28 @@ review_date: 2026-06-08
 
 This document provides solutions to common issues you may encounter when configuring or using the Amazon Managed Service for Prometheus data source. For configuration instructions, refer to [Configure the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
 
+## Plugin and interface errors
+
+These errors occur when the plugin is outdated or fails to load in the Grafana interface.
+
+### "Plugin not found", "Datasource not found", or blank settings tabs
+
+An outdated plugin version is a common cause of interface errors and missing settings.
+
+**Symptoms:**
+
+- The data source settings tabs are blank or fail to render.
+- Errors such as **Plugin not found** or **Datasource not found** appear.
+- The browser console shows JavaScript errors such as `TypeError: Cannot read properties of undefined`.
+
+**Solutions:**
+
+1. Check the installed plugin version. Navigate to **Plugins and data** > **Plugins** and select **Amazon Managed Service for Prometheus**.
+1. If an update is available, click **Update** to install the latest version. In Grafana Cloud, plugins update automatically.
+1. After updating, reload the data source configuration page.
+1. Confirm your Grafana version meets the plugin's minimum requirement. For the supported versions, refer to [Requirements](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/#requirements).
+1. If the errors persist, restart Grafana and clear your browser cache.
+
 ## Authentication errors
 
 These errors occur when AWS credentials are invalid, missing, or don't have the required permissions, or when the SigV4 authentication option isn't enabled on your instance.
@@ -319,28 +341,6 @@ This error appears when Grafana can't retrieve the alerting and recording rules 
 {{< admonition type="note" >}}
 The **Unable to fetch alert rules** error isn't always a configuration problem. When IAM permissions and the workspace URL are correct, the cause can be platform-side and require escalation to Grafana Support rather than a change on your end.
 {{< /admonition >}}
-
-## Plugin and interface errors
-
-These errors occur when the plugin is outdated or fails to load in the Grafana interface.
-
-### "Plugin not found", "Datasource not found", or blank settings tabs
-
-An outdated plugin version is a common cause of interface errors and missing settings.
-
-**Symptoms:**
-
-- The data source settings tabs are blank or fail to render.
-- Errors such as **Plugin not found** or **Datasource not found** appear.
-- The browser console shows JavaScript errors such as `TypeError: Cannot read properties of undefined`.
-
-**Solutions:**
-
-1. Check the installed plugin version. Navigate to **Plugins and data** > **Plugins** and select **Amazon Managed Service for Prometheus**.
-1. If an update is available, click **Update** to install the latest version. In Grafana Cloud, plugins update automatically.
-1. After updating, reload the data source configuration page.
-1. Confirm your Grafana version meets the plugin's minimum requirement. For the supported versions, refer to [Requirements](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/#requirements).
-1. If the errors persist, restart Grafana and clear your browser cache.
 
 ## Enable debug logging
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -337,7 +337,7 @@ This error appears when Grafana can't retrieve the alerting and recording rules 
 | Rule management not enabled | Enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). |
 | Missing rule read permissions | Grant `aps:ListRules`, `aps:ListRuleGroupsNamespaces`, and `aps:DescribeRuleGroupsNamespace` to the identity. |
 | No rule groups namespace | Create a rule groups namespace in the workspace. The ruler returns an error until at least one namespace exists. |
-| Incorrect workspace URL | Verify the **Prometheus server URL** is correct. The data source serves the ruler from the `/api/v1/rules` and `/config/v1/rules` paths under this URL, so no separate ruler URL is required. |
+| Incorrect workspace URL | Verify the **Prometheus server URL** is correct. The data source serves the ruler from the `/rules` and `/config/v1/rules` paths under this URL, so no separate ruler URL is required. |
 | Platform-side issue | If your configuration and permissions are correct, this error can be a Grafana Cloud platform issue, such as a data proxy problem on a specific cluster. Contact [Grafana Support](https://grafana.com/help/) to escalate. |
 
 {{< admonition type="note" >}}

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -50,6 +50,8 @@ An outdated plugin version is a common cause of interface errors and missing set
 1. Confirm your Grafana version meets the plugin's minimum requirement. For the supported versions, refer to [Requirements](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/#requirements).
 1. If the errors persist, restart Grafana and clear your browser cache.
 
+For install, upgrade, and catalog issues, refer to [Troubleshoot installation issues](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/install/#troubleshoot-installation-issues).
+
 ## Authentication errors
 
 These errors occur when AWS credentials are invalid, missing, or don't have the required permissions, or when the SigV4 authentication option isn't enabled on your instance.

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -19,18 +19,32 @@ labels:
     - enterprise
     - oss
 menuTitle: Troubleshooting
-title: Troubleshoot the Amazon Managed Service for Prometheus data source
+title: Troubleshoot Amazon Managed Service for Prometheus issues
 weight: 500
 review_date: 2026-06-08
 ---
 
-# Troubleshoot the Amazon Managed Service for Prometheus data source
+# Troubleshoot Amazon Managed Service for Prometheus issues
 
 This document provides solutions to common issues you may encounter when configuring or using the Amazon Managed Service for Prometheus data source. For configuration instructions, refer to [Configure the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
 
 ## Authentication errors
 
-These errors occur when AWS credentials are invalid, missing, or don't have the required permissions.
+These errors occur when AWS credentials are invalid, missing, or don't have the required permissions, or when the SigV4 authentication option isn't enabled on your instance.
+
+### SigV4 authentication option is missing
+
+In some Grafana Cloud instances, the SigV4 authentication option isn't enabled by default and must be turned on for your instance.
+
+**Symptoms:**
+
+- The authentication drop-down shows only options such as **Basic auth**, **Forward OAuth Identity**, and **No Authentication**.
+- **SigV4 auth** doesn't appear as an authentication method.
+- You can't complete the data source configuration because there's no way to enter AWS credentials.
+
+**Solution:**
+
+If the SigV4 option is missing from the authentication drop-down in Grafana Cloud, contact [Grafana Support](https://grafana.com/help/) to enable SigV4 authentication for your instance. After Support enables it and the instance restarts, the **SigV4 auth** option appears in the authentication drop-down.
 
 ### "Access denied" or "Authorization failed"
 
@@ -52,7 +66,18 @@ These errors indicate that the identity Grafana uses can't query the workspace.
 | Wrong region | Verify the **Default Region** matches the region of your workspace. |
 | Assume-role trust issue | Verify the role's trust policy allows the Grafana identity to assume it and that the **External ID** matches. |
 
-**Example IAM policy that grants query access:**
+**Required IAM permissions:**
+
+Grant the identity the `aps` permissions for the features you use. Missing permissions, such as `aps:ListRules` or `aps:DescribeRuleGroupsNamespace`, are a common cause of access-denied errors.
+
+| Capability | Required `aps` actions |
+|------------|------------------------|
+| Query metrics | `aps:QueryMetrics`, `aps:GetLabels`, `aps:GetSeries`, `aps:GetMetricMetadata` |
+| Read alerting and recording rules | `aps:ListRules`, `aps:ListRuleGroupsNamespaces`, `aps:DescribeRuleGroupsNamespace` |
+| Manage alerting and recording rules | `aps:CreateRuleGroupsNamespace`, `aps:PutRuleGroupsNamespace`, `aps:DeleteRuleGroupsNamespace` |
+| Manage the alert manager | `aps:GetAlertManagerSilence`, `aps:CreateAlertManagerSilence`, `aps:PutAlertManagerSilences`, `aps:DeleteAlertManagerSilence` |
+
+**Example IAM policy:**
 
 ```json
 {
@@ -64,13 +89,76 @@ These errors indicate that the identity Grafana uses can't query the workspace.
         "aps:QueryMetrics",
         "aps:GetLabels",
         "aps:GetSeries",
-        "aps:GetMetricMetadata"
+        "aps:GetMetricMetadata",
+        "aps:ListRules",
+        "aps:ListRuleGroupsNamespaces",
+        "aps:DescribeRuleGroupsNamespace",
+        "aps:CreateRuleGroupsNamespace",
+        "aps:PutRuleGroupsNamespace",
+        "aps:DeleteRuleGroupsNamespace"
       ],
       "Resource": "arn:aws:aps:<REGION>:<ACCOUNT_ID>:workspace/<WORKSPACE_ID>"
     }
   ]
 }
 ```
+
+If you only query metrics and don't manage rules from Grafana, you can omit the rule and alert manager actions.
+
+### "Access denied" when assuming a role
+
+When you use an assume-role configuration, the role's trust policy must allow the calling identity to assume it. For Grafana Cloud, the calling identity is the Grafana Labs AWS account `008923505280`.
+
+**Symptoms:**
+
+- Save & test fails even though the role has the correct `aps` permissions.
+- Logs mention `AccessDenied` on `sts:AssumeRole`.
+
+**Solutions:**
+
+1. Verify the trust policy lists the correct principal. For Grafana Cloud, use the Grafana Labs account `008923505280`.
+1. Verify the **External ID** in the data source configuration matches the `sts:ExternalId` condition in the trust policy.
+1. Verify the **Assume Role ARN** in the data source matches the role you configured.
+
+**Example trust policy:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::008923505280:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "<EXTERNAL_ID>"
+        }
+      }
+    }
+  ]
+}
+```
+
+For a self-managed Grafana instance, replace `008923505280` with the account or IAM user ARN that runs Grafana.
+
+### "InvalidClientTokenId" or STS AssumeRole 403 errors
+
+These errors occur when AWS Security Token Service (STS) rejects the credentials used to assume the role.
+
+**Symptoms:**
+
+- Save & test fails with `InvalidClientTokenId` or an HTTP `403` from STS.
+- Logs mention `sts:AssumeRole` failures.
+
+**Solutions:**
+
+1. Verify the base credentials, such as the access key or instance role, are valid and not expired.
+1. Verify STS is enabled for the region. If you use regional STS endpoints, confirm the region is activated in your AWS account.
+1. Verify the **Assume Role ARN** is correct and the role exists in the target account.
+1. Verify the base identity has `sts:AssumeRole` permission for the target role.
 
 ### "SignatureDoesNotMatch" or signature errors
 
@@ -103,6 +191,24 @@ These errors indicate a network or endpoint problem rather than an authenticatio
 1. Verify network connectivity from the Grafana server to the workspace endpoint.
 1. Check that firewall rules allow outbound HTTPS on port 443.
 1. For Grafana Cloud accessing a private endpoint, configure [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
+
+### VPC endpoint and PrivateLink access denied
+
+If you reach your workspace through an AWS PrivateLink (VPC) endpoint, the endpoint policy can block requests even when IAM permissions are correct.
+
+**Symptoms:**
+
+- Requests fail with access-denied errors only when routed through the VPC endpoint.
+- The same identity works from a public endpoint but not the private one.
+
+**VPC endpoint policy checklist:**
+
+1. Confirm the VPC endpoint for `com.amazonaws.<REGION>.aps-workspaces` exists and is in the **Available** state.
+1. Confirm the endpoint policy allows the calling principal. For Grafana Cloud, allow the Grafana Labs account `008923505280` or the role it assumes.
+1. Confirm the endpoint policy allows the required `aps` actions, such as `aps:QueryMetrics` and the label and series actions.
+1. Confirm the endpoint policy `Resource` includes your workspace ARN.
+1. Confirm the endpoint's security group allows inbound HTTPS on port 443 from the source network.
+1. Confirm DNS resolves the workspace endpoint to the private endpoint addresses.
 
 ## Query errors
 
@@ -186,6 +292,55 @@ Amazon Managed Service for Prometheus enforces request quotas.
 1. Increase the query step or **Min step** to request fewer data points.
 1. Enable query caching in Grafana, available in Grafana Enterprise and Grafana Cloud.
 1. Request a quota increase from AWS for your workspace.
+
+## Alerting errors
+
+These errors occur when Grafana can't load or manage rules stored in your workspace.
+
+### "Unable to fetch alert rules"
+
+This error appears when Grafana can't retrieve the alerting and recording rules from the workspace ruler.
+
+**Symptoms:**
+
+- The Grafana Alerting UI shows **Unable to fetch alert rules**.
+- Data-source-managed rules don't load even though queries work and IAM permissions are correct.
+
+**Possible causes and solutions:**
+
+| Cause | Solution |
+|-------|----------|
+| Rule management not enabled | Enable **Manage alerts via Alerting UI** on the data source [configuration page](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/). |
+| Missing rule read permissions | Grant `aps:ListRules`, `aps:ListRuleGroupsNamespaces`, and `aps:DescribeRuleGroupsNamespace` to the identity. |
+| No rule groups namespace | Create a rule groups namespace in the workspace. The ruler returns an error until at least one namespace exists. |
+| Incorrect workspace URL | Verify the **Prometheus server URL** is correct. The data source serves the ruler from the `/api/v1/rules` and `/config/v1/rules` paths under this URL, so no separate ruler URL is required. |
+| Platform-side issue | If your configuration and permissions are correct, this error can be a Grafana Cloud platform issue, such as a data proxy problem on a specific cluster. Contact [Grafana Support](https://grafana.com/help/) to escalate. |
+
+{{< admonition type="note" >}}
+The **Unable to fetch alert rules** error isn't always a configuration problem. When IAM permissions and the workspace URL are correct, the cause can be platform-side and require escalation to Grafana Support rather than a change on your end.
+{{< /admonition >}}
+
+## Plugin and interface errors
+
+These errors occur when the plugin is outdated or fails to load in the Grafana interface.
+
+### "Plugin not found", "Datasource not found", or blank settings tabs
+
+An outdated plugin version is a common cause of interface errors and missing settings.
+
+**Symptoms:**
+
+- The data source settings tabs are blank or fail to render.
+- Errors such as **Plugin not found** or **Datasource not found** appear.
+- The browser console shows JavaScript errors such as `TypeError: Cannot read properties of undefined`.
+
+**Solutions:**
+
+1. Check the installed plugin version. Navigate to **Plugins and data** > **Plugins** and select **Amazon Managed Service for Prometheus**.
+1. If an update is available, click **Update** to install the latest version. In Grafana Cloud, plugins update automatically.
+1. After updating, reload the data source configuration page.
+1. Confirm your Grafana version meets the plugin's minimum requirement. For the supported versions, refer to [Requirements](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/#requirements).
+1. If the errors persist, restart Grafana and clear your browser cache.
 
 ## Enable debug logging
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -1,0 +1,217 @@
+---
+aliases:
+  - ../data-sources/aws-prometheus/troubleshooting/
+  - ../data-sources/amazon-prometheus/troubleshooting/
+description: Troubleshooting guide for the Amazon Managed Service for Prometheus data source in Grafana.
+keywords:
+  - grafana
+  - prometheus
+  - amazon
+  - aws
+  - amp
+  - troubleshooting
+  - errors
+  - authentication
+  - query
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Troubleshooting
+title: Troubleshoot the Amazon Managed Service for Prometheus data source
+weight: 500
+review_date: 2026-06-08
+---
+
+# Troubleshoot the Amazon Managed Service for Prometheus data source
+
+This document provides solutions to common issues you may encounter when configuring or using the Amazon Managed Service for Prometheus data source. For configuration instructions, refer to [Configure the Amazon Managed Service for Prometheus data source](https://grafana.com/docs/plugins/grafana-amazonprometheus-datasource/latest/configure/).
+
+## Authentication errors
+
+These errors occur when AWS credentials are invalid, missing, or don't have the required permissions.
+
+### "Access denied" or "Authorization failed"
+
+These errors indicate that the identity Grafana uses can't query the workspace.
+
+**Symptoms:**
+
+- Save & test fails with an authorization error.
+- Queries return access denied messages.
+- Metrics and labels don't load in the query editor.
+
+**Possible causes and solutions:**
+
+| Cause | Solution |
+|-------|----------|
+| Missing permissions | Attach an IAM policy that grants query permissions to the identity. Refer to the [Amazon Managed Service for Prometheus IAM documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/security-iam.html). |
+| Invalid credentials | Verify the access key ID and secret access key in the AWS console. Regenerate them if necessary. |
+| Expired credentials | Create new credentials and update the data source configuration. |
+| Wrong region | Verify the **Default Region** matches the region of your workspace. |
+| Assume-role trust issue | Verify the role's trust policy allows the Grafana identity to assume it and that the **External ID** matches. |
+
+**Example IAM policy that grants query access:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "aps:QueryMetrics",
+        "aps:GetLabels",
+        "aps:GetSeries",
+        "aps:GetMetricMetadata"
+      ],
+      "Resource": "arn:aws:aps:<REGION>:<ACCOUNT_ID>:workspace/<WORKSPACE_ID>"
+    }
+  ]
+}
+```
+
+### "SignatureDoesNotMatch" or signature errors
+
+This error means AWS rejected the request signature.
+
+**Solutions:**
+
+1. Verify the secret access key is correct and has no leading or trailing whitespace.
+1. Verify the **Default Region** matches the workspace region, because SigV4 signs requests per region.
+1. Verify the **Service** field is set to `aps` unless AWS instructs you to use a different value.
+1. Verify the Grafana server clock is accurate, because a large clock skew invalidates signatures.
+
+## Connection errors
+
+These errors occur when Grafana can't reach the workspace endpoint.
+
+### "Connection refused" or timeout errors
+
+These errors indicate a network or endpoint problem rather than an authentication problem.
+
+**Symptoms:**
+
+- The data source test times out.
+- Queries fail with network errors.
+- Connection issues are intermittent.
+
+**Solutions:**
+
+1. Verify the **Prometheus server URL** is the correct workspace query endpoint and includes the workspace path.
+1. Verify network connectivity from the Grafana server to the workspace endpoint.
+1. Check that firewall rules allow outbound HTTPS on port 443.
+1. For Grafana Cloud accessing a private endpoint, configure [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
+
+## Query errors
+
+These errors occur when running queries against the workspace.
+
+### "No data" or empty results
+
+A query can succeed yet return no data.
+
+**Symptoms:**
+
+- The query runs without error but returns no data.
+- Panels show a **No data** message.
+
+**Possible causes and solutions:**
+
+| Cause | Solution |
+|-------|----------|
+| Time range has no data | Expand the dashboard time range or verify the metric exists for that period. |
+| Metric name typo | Verify the metric name with the metrics browser. |
+| Label selector too narrow | Remove or broaden label filters in the query. |
+| Data not yet ingested | Verify your Prometheus agent or collector is sending data to the workspace. |
+
+### Query timeout
+
+Large or unbounded queries can exceed the query timeout.
+
+**Symptoms:**
+
+- The query runs for a long time and then fails.
+- The error mentions a timeout or query limit.
+
+**Solutions:**
+
+1. Narrow the time range to reduce the data volume.
+1. Add label filters to reduce the number of series.
+1. Increase the **Query timeout** on the data source configuration page.
+1. Use recording rules to pre-compute expensive expressions.
+
+## Template variable errors
+
+These errors occur when using template variables with the data source.
+
+### Variables return no values
+
+Empty variables usually point to a connection or permissions problem.
+
+**Solutions:**
+
+1. Verify the data source connection works by running Save & test.
+1. Verify the variable query uses a valid function such as `label_values()`.
+1. Check that parent variables in a chain have valid selections.
+1. Verify the identity has permission to list labels and series.
+
+### Variables are slow to load
+
+Large workspaces can make variable queries slow.
+
+**Solutions:**
+
+1. Set the variable refresh to **On dashboard load** instead of **On time range change**.
+1. Narrow the scope of the variable query with label filters.
+1. Enable **Disable metric lookup** if you don't need metric autocomplete.
+
+## Performance issues
+
+These issues relate to slow queries or AWS service limits.
+
+### Throttling or rate limit errors
+
+Amazon Managed Service for Prometheus enforces request quotas.
+
+**Symptoms:**
+
+- Errors mention throttling or rate limits.
+- Dashboard panels intermittently fail to load.
+
+**Solutions:**
+
+1. Reduce the dashboard refresh frequency.
+1. Increase the query step or **Min step** to request fewer data points.
+1. Enable query caching in Grafana, available in Grafana Enterprise and Grafana Cloud.
+1. Request a quota increase from AWS for your workspace.
+
+## Enable debug logging
+
+To capture detailed error information for troubleshooting:
+
+1. Set the Grafana log level to `debug` in the configuration file:
+
+   ```ini
+   [log]
+   level = debug
+   ```
+
+1. Review logs in `/var/log/grafana/grafana.log`, or your configured log location.
+1. Look for entries from the `grafana-amazonprometheus-datasource` plugin that include request and response details.
+1. Reset the log level to `info` after troubleshooting to avoid excessive log volume.
+
+## Get additional help
+
+If you've tried these solutions and still encounter issues:
+
+1. Check the [Grafana community forums](https://community.grafana.com/) for similar issues.
+1. Review the [plugin GitHub issues](https://github.com/grafana/grafana-amazonprometheus-datasource/issues) for known bugs.
+1. Consult the [Amazon Managed Service for Prometheus documentation](https://docs.aws.amazon.com/prometheus/) for service-specific guidance.
+1. Contact Grafana Support if you're an Enterprise, Cloud Pro, or Cloud Contracted user.
+1. When reporting issues, include:
+   - Grafana version and plugin version.
+   - Error messages, with sensitive information redacted.
+   - Steps to reproduce.
+   - Relevant configuration, with credentials redacted.

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,0 +1,7 @@
+# List of projects to provide to the make-docs script.
+# Format is PROJECT[:[VERSION][:[REPOSITORY][:[DIRECTORY]]]]
+# The following PROJECTS value mounts content for the "grafana-amazonprometheus-datasource" project, at the "latest" version, which is the default if not explicitly set.
+# This results in the content being served at /docs/grafana-amazonprometheus-datasource/latest/.
+# The source of the content is the current repository which is determined by the name of the parent directory of the git root.
+# This overrides the default behavior of assuming the repository directory is the same as the project name.
+PROJECTS := grafana-amazonprometheus-datasource::$(notdir $(basename $(shell git rev-parse --show-toplevel)))


### PR DESCRIPTION
Overhaul of the Amazon Managed Service for Prometheus data source documentation. The previous docs consisted of a single `_index.md` page. This update restructures the content into a flat, multi-page layout with dedicated topic pages, following data source documentation standards, and adds the Writers' Toolkit `make docs` tooling. Also included content from Zendesk tickets.

All content was verified against the current plugin codebase for accuracy, including supported features, SigV4 authentication options, provisioning keys, query editor components, and the alerting and annotation behavior the plugin inherits from core Prometheus.

## Changes

Restructured **_index.md** into an overview page:
Added supported features table (metrics, alerting, annotations, exemplars), requirements with supported Grafana versions, restructured "Get started" links, refined "Migrate from core Prometheus" section, pre-built dashboards, plugin updates, and related resources

**install.md (new):**
Requirements, install steps for Grafana Cloud, self-managed CLI, Docker, Kubernetes (Helm and init container), and air-gapped environments, verification, upgrade and rollback, uninstall, and install-specific troubleshooting

**configure.md (new):**
Prerequisites, key concepts, add data source steps, SigV4 authentication providers and fields, the configurable Service field, additional settings, connection verification, Private data source connect, and provisioning examples (YAML and Terraform)

**query-editor.md (new):**
Builder and Code modes, metrics browser, kickstart, query options, macros table, categorized PromQL query examples, and real-world use cases

**template-variables.md (new):**
Supported variable types, query variable functions, query type selector, per-function examples, chained variables, and variable usage with multi-value formatting

**annotations.md (new):**
Annotation query setup, field mappings including "Series value as timestamp", and examples for firing alerts, target-down, host reboots, and event-time metrics

**alerting.md (new):**
Grafana-managed vs data-source-managed rules, recording vs alerting rule definitions, an example alert expression, required IAM rule-management permissions, and the ruler endpoint requirement

**troubleshooting.md (new):**
Organized by user journey (plugin/interface, authentication, connection, query, template variable, performance, alerting), with symptoms and solutions, IAM permission and trust policy examples, a VPC endpoint/PrivateLink checklist, debug logging, and "Get additional help". Incorporates findings from a Zendesk ticket review (SigV4 not enabled, IAM/trust policy misconfiguration, plugin version UI errors, and "Unable to fetch alert rules")

**Makefile, variables.mk, docs.mk, make-docs (new):**
Grafana Writers' Toolkit docs build setup for local preview (`make docs`) and prose linting (`make vale`)

