### PR TITLE
fix: preserve PromQL queries when switching a panel from a Prometheus data source to AMP

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -60,6 +60,8 @@
     "alertstate",
     "curlimages",
     "jsonencode",
-    "topk"
+    "topk",
+    "azureprometheus",
+    "testdata"
   ]
 }

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -47,6 +47,12 @@ describe('AmazonPrometheusDatasource', () => {
     });
   });
 
+  describe('constructor arity', () => {
+    it('should have exactly one required constructor parameter, or Grafana 11.x loads it as an Angular plugin', () => {
+      expect(AmazonPrometheusDatasource.length).toBe(1);
+    });
+  });
+
   describe('importQueries', () => {
     const promQueries: PromQuery[] = [
       { refId: 'A', expr: 'avg(node_cpu_seconds_total{mode="idle"})' },

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,100 @@
+import {
+  AbstractLabelOperator,
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  hasQueryExportSupport,
+  hasQueryImportSupport,
+} from '@grafana/data';
+import { TemplateSrv } from '@grafana/runtime';
+import { PrometheusLanguageProviderInterface, PromOptions, PromQuery } from '@grafana/prometheus';
+import { DataQuery } from '@grafana/schema';
+
+import { AmazonPrometheusDatasource } from './datasource';
+
+const instanceSettings = {
+  id: 1,
+  uid: 'amp-uid',
+  type: 'grafana-amazonprometheus-datasource',
+  name: 'AMP',
+  access: 'proxy',
+  url: '/api/datasources/proxy/1',
+  jsonData: { httpMethod: 'POST' },
+  readOnly: false,
+} as unknown as DataSourceInstanceSettings<PromOptions>;
+
+const templateSrv = {
+  replace: (value: string) => value,
+  getVariables: () => [],
+  containsTemplate: () => false,
+  updateTimeRange: () => {},
+} as unknown as TemplateSrv;
+
+const languageProvider = {} as unknown as PrometheusLanguageProviderInterface;
+
+const createDatasource = () => new AmazonPrometheusDatasource(instanceSettings, templateSrv, languageProvider);
+
+describe('AmazonPrometheusDatasource', () => {
+  describe('query preservation when switching data source type', () => {
+    it('should not advertise abstract query import support, so Grafana falls back to importQueries', () => {
+      // updateQueries in Grafana core prefers the lossy abstract-query path
+      // (label matchers only, aggregations dropped) whenever this returns true.
+      // https://github.com/grafana/grafana-amazonprometheus-datasource/issues/477
+      expect(hasQueryImportSupport(createDatasource())).toBe(false);
+    });
+
+    it('should keep advertising abstract query export support for switches away from AMP', () => {
+      expect(hasQueryExportSupport(createDatasource())).toBe(true);
+    });
+  });
+
+  describe('importQueries', () => {
+    const promQueries: PromQuery[] = [
+      { refId: 'A', expr: 'avg(node_cpu_seconds_total{mode="idle"})' },
+      { refId: 'B', expr: 'rate(http_requests_total[5m])' },
+    ];
+
+    it('should preserve queries verbatim when switching from a core Prometheus data source', async () => {
+      const origin = { meta: { id: 'prometheus' } } as DataSourceApi;
+
+      const imported = await createDatasource().importQueries(promQueries, origin);
+
+      expect(imported).toEqual(promQueries);
+    });
+
+    it('should preserve queries verbatim when switching from the Azure Prometheus data source', async () => {
+      const origin = { meta: { id: 'grafana-azureprometheus-datasource' } } as DataSourceApi;
+
+      const imported = await createDatasource().importQueries(promQueries, origin);
+
+      expect(imported).toEqual(promQueries);
+    });
+
+    it('should build queries from abstract queries when the origin exports them', async () => {
+      const origin = {
+        meta: { id: 'graphite' },
+        exportToAbstractQueries: async (queries: DataQuery[]) => [
+          {
+            refId: 'A',
+            labelMatchers: [
+              { name: '__name__', operator: AbstractLabelOperator.Equal, value: 'node_cpu_seconds_total' },
+              { name: 'job', operator: AbstractLabelOperator.Equal, value: 'node' },
+            ],
+          },
+        ],
+      } as unknown as DataSourceApi;
+
+      const imported = await createDatasource().importQueries([{ refId: 'A' }], origin);
+
+      expect(imported).toHaveLength(1);
+      expect(imported[0].expr).toBe('{__name__="node_cpu_seconds_total", job="node"}');
+    });
+
+    it('should return no queries when the origin has no compatible queries', async () => {
+      const origin = { meta: { id: 'testdata' } } as DataSourceApi;
+
+      const imported = await createDatasource().importQueries(promQueries, origin);
+
+      expect(imported).toEqual([]);
+    });
+  });
+});

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -62,6 +62,7 @@ describe('AmazonPrometheusDatasource', () => {
     it('should preserve queries verbatim when switching from a core Prometheus data source', async () => {
       const origin = { meta: { id: 'prometheus' } } as DataSourceApi;
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deliberate: importQueries is the only hook that receives raw origin queries, see datasource.ts
       const imported = await createDatasource().importQueries(promQueries, origin);
 
       expect(imported).toEqual(promQueries);
@@ -70,6 +71,7 @@ describe('AmazonPrometheusDatasource', () => {
     it('should preserve queries verbatim when switching from the Azure Prometheus data source', async () => {
       const origin = { meta: { id: 'grafana-azureprometheus-datasource' } } as DataSourceApi;
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deliberate: importQueries is the only hook that receives raw origin queries, see datasource.ts
       const imported = await createDatasource().importQueries(promQueries, origin);
 
       expect(imported).toEqual(promQueries);
@@ -89,6 +91,7 @@ describe('AmazonPrometheusDatasource', () => {
         ],
       } as unknown as DataSourceApi;
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deliberate: importQueries is the only hook that receives raw origin queries, see datasource.ts
       const imported = await createDatasource().importQueries([{ refId: 'A' }], origin);
 
       expect(imported).toHaveLength(1);
@@ -98,6 +101,7 @@ describe('AmazonPrometheusDatasource', () => {
     it('should return no queries when the origin has no compatible queries', async () => {
       const origin = { meta: { id: 'testdata' } } as DataSourceApi;
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deliberate: importQueries is the only hook that receives raw origin queries, see datasource.ts
       const imported = await createDatasource().importQueries(promQueries, origin);
 
       expect(imported).toEqual([]);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,5 +1,11 @@
-import { DataSourceApi, hasQueryExportSupport } from '@grafana/data';
-import { PrometheusDatasource, PromQuery } from '@grafana/prometheus';
+import { DataSourceApi, DataSourceInstanceSettings, hasQueryExportSupport } from '@grafana/data';
+import {
+  PrometheusDatasource,
+  PrometheusLanguageProviderInterface,
+  PromOptions,
+  PromQuery,
+} from '@grafana/prometheus';
+import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 
 // Data source types whose queries are PromQL, so they can be reused as-is.
@@ -21,6 +27,17 @@ const importFromAbstractQueries = PrometheusDatasource.prototype.importFromAbstr
 delete (PrometheusDatasource.prototype as Partial<PrometheusDatasource>).importFromAbstractQueries;
 
 export class AmazonPrometheusDatasource extends PrometheusDatasource {
+  // Grafana 11.x treats a datasource class as a legacy Angular plugin unless
+  // its constructor length is exactly 1, so the second parameter must have a
+  // default value rather than being merely optional.
+  constructor(
+    instanceSettings: DataSourceInstanceSettings<PromOptions>,
+    templateSrv: TemplateSrv = getTemplateSrv(),
+    languageProvider?: PrometheusLanguageProviderInterface
+  ) {
+    super(instanceSettings, templateSrv, languageProvider);
+  }
+
   async importQueries(queries: DataQuery[], originDataSource: DataSourceApi): Promise<PromQuery[]> {
     if (PROMQL_COMPATIBLE_TYPES.has(originDataSource.meta.id)) {
       // The origin queries are PromQL queries, they only need a shallow copy.

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,0 +1,39 @@
+import { DataSourceApi, hasQueryExportSupport } from '@grafana/data';
+import { PrometheusDatasource, PromQuery } from '@grafana/prometheus';
+import { DataQuery } from '@grafana/schema';
+
+// Data source types whose queries are PromQL, so they can be reused as-is.
+const PROMQL_COMPATIBLE_TYPES = new Set([
+  'prometheus',
+  'grafana-amazonprometheus-datasource',
+  'grafana-azureprometheus-datasource',
+]);
+
+// Grafana routes data source switches through the abstract-query flow whenever
+// `importFromAbstractQueries` exists anywhere on the prototype chain
+// (`hasQueryImportSupport` uses the `in` operator). That flow keeps only label
+// matchers, dropping aggregations and functions from the PromQL expression, so
+// the inherited method has to be removed rather than overridden for Grafana to
+// fall back to `importQueries` below. The plugin bundles its own copy of
+// `@grafana/prometheus`, so mutating the prototype affects nothing else.
+// https://github.com/grafana/grafana-amazonprometheus-datasource/issues/477
+const importFromAbstractQueries = PrometheusDatasource.prototype.importFromAbstractQueries;
+delete (PrometheusDatasource.prototype as Partial<PrometheusDatasource>).importFromAbstractQueries;
+
+export class AmazonPrometheusDatasource extends PrometheusDatasource {
+  async importQueries(queries: DataQuery[], originDataSource: DataSourceApi): Promise<PromQuery[]> {
+    if (PROMQL_COMPATIBLE_TYPES.has(originDataSource.meta.id)) {
+      // The origin queries are PromQL queries, they only need a shallow copy.
+      return queries.map((query) => ({ ...query }) as PromQuery);
+    }
+
+    // Non-PromQL origins (Graphite, Loki, ...) keep the label-matcher
+    // conversion these switches used before.
+    if (hasQueryExportSupport(originDataSource)) {
+      const abstractQueries = await originDataSource.exportToAbstractQueries(queries);
+      return importFromAbstractQueries.call(this, abstractQueries);
+    }
+
+    return [];
+  }
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,16 +1,17 @@
 import { DataSourcePlugin } from '@grafana/data';
 import { initPluginTranslations } from '@grafana/i18n';
-import { loadResources, PromCheatSheet, PrometheusDatasource, PromQueryEditorByApp } from '@grafana/prometheus';
+import { loadResources, PromCheatSheet, PromQueryEditorByApp } from '@grafana/prometheus';
 
 // custom config made with sigV4 auth
 import { ConfigEditor } from './configuration/ConfigEditor';
+import { AmazonPrometheusDatasource } from './datasource';
 import pluginJson from './plugin.json';
 
 if (process.env.NODE_ENV !== 'test') {
   void initPluginTranslations(pluginJson.id, [loadResources]);
 }
 
-export const plugin = new DataSourcePlugin(PrometheusDatasource)
+export const plugin = new DataSourcePlugin(AmazonPrometheusDatasource)
   .setQueryEditor(PromQueryEditorByApp)
   .setConfigEditor(ConfigEditor)
   .setQueryEditorHelp(PromCheatSheet);


### PR DESCRIPTION
## What

When a panel or Explore query is switched from a core Prometheus data source (or another PromQL-compatible data source) to this plugin, the PromQL expression is now carried over unchanged. Previously the switch went through Grafana's abstract query flow, which keeps only the metric name and label matchers, so functions and aggregations such as `avg(...) by (...)` were silently dropped.

Grafana chooses that lossy flow whenever the target data source exposes `importFromAbstractQueries` (the `hasQueryImportSupport` check walks the prototype chain), so the plugin now removes the inherited method and implements the `importQueries` fallback instead:

- PromQL-compatible origins (core Prometheus, Azure Prometheus): queries are reused as-is
- origins that export abstract queries (Graphite, Loki): converted to label matchers, matching the previous behaviour
- anything else: cleared, and Grafana inserts its default query as before

The datasource is now a subclass of `PrometheusDatasource`, which requires care on Grafana 11.x: the frontend there treats a datasource class as a legacy Angular plugin unless its constructor takes exactly one required argument, and a subclass without an explicit constructor has `Function.length === 0`. The subclass therefore declares a single-required-argument constructor (later parameters take defaults), with a unit test guarding the arity.

Switching away from this plugin to core Prometheus still goes through the abstract query flow and remains lossy. That direction is controlled by the core Prometheus importer and needs a fix in grafana/grafana.

## User-facing impact

Dashboards no longer lose aggregations, functions or ranges from queries when a panel's data source is changed from Prometheus (or Azure Prometheus) to Amazon Managed Service for Prometheus. No configuration changes are required.

## Testing

- Unit tests cover the import/export support contract, all `importQueries` branches, and the Grafana 11 constructor arity requirement
- Playwright E2E suite passes on the full CI matrix (Grafana 11.6.16, 12.0.10, 12.2.10, 12.4.5, 13.1.0 and nightly)
- Verified end to end in Grafana via the repo's docker compose: `avg(node_cpu_seconds_total{mode="idle"}) by (instance)` survives a switch from core Prometheus to this plugin, where previously it collapsed to `{__name__="node_cpu_seconds_total", mode="idle"}`
- Verified against a live Amazon Managed Service for Prometheus workspace with SigV4 auth: health check, live range queries, and the preserved query rendering data after the switch

Fixes #477