### PR TITLE
chore(e2e): add live AMP coverage

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,33 @@
+name: Scheduled Cloud E2E tests
+
+on:
+  # Run nightly against the shared Cloud instance (DSE2EDEV)
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  # Allow engineers to run Cloud E2E on-demand (useful for debugging)
+  workflow_dispatch:
+
+# Reusable workflows can only narrow caller permissions, not escalate.
+# `id-token: write` is needed by the Vault OIDC step in playwright-cloud.yml.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  playwright-cloud:
+    # Intentionally pinned to @main: data-sources-ci-workflows does not
+    # publish versioned tags for this workflow yet. Allowed by the zizmor
+    # policy (`grafana/*: any`); review periodically.
+    uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      pdc-network-name: datasources-pdc-network-aws-datasourcese2e
+      repo-secrets: |
+        DS_INSTANCE_URL=amazonManagedPrometheus:url
+        DS_INSTANCE_SIGV4_REGION=amazonManagedPrometheus:json_sigV4Region
+        DS_INSTANCE_SIGV4_ACCESS_KEY=amazonManagedPrometheus:secure_sigV4AccessKey
+        DS_INSTANCE_SIGV4_SECRET_KEY=amazonManagedPrometheus:secure_sigV4SecretKey
+        DS_PDC_NETWORK_NAME=amazonManagedPrometheus:e2ePdcNetworkName

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,4 +36,10 @@ jobs:
       environment: 'prod'
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
+      playwright-secrets: |
+        DS_INSTANCE_URL=amazonManagedPrometheus:url
+        DS_INSTANCE_SIGV4_REGION=amazonManagedPrometheus:json_sigV4Region
+        DS_INSTANCE_SIGV4_ACCESS_KEY=amazonManagedPrometheus:secure_sigV4AccessKey
+        DS_INSTANCE_SIGV4_SECRET_KEY=amazonManagedPrometheus:secure_sigV4SecretKey
       github-draft-release: false # publish the github release directly, skipping the draft step
+

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,6 +17,9 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      # Fork PRs cannot read Vault secrets (isTrusted=false). Use the smoke config
+      # which excludes tests tagged `@aws` that need the live AMP workspace.
+      playwright-config: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'playwright.smoke.config.ts' || 'playwright.config.ts' }}
       playwright-secrets: |
         DS_INSTANCE_URL=amazonManagedPrometheus:url
         DS_INSTANCE_SIGV4_REGION=amazonManagedPrometheus:json_sigV4Region

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,3 +17,20 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      playwright-secrets: |
+        DS_INSTANCE_URL=amazonManagedPrometheus:url
+        DS_INSTANCE_SIGV4_REGION=amazonManagedPrometheus:json_sigV4Region
+        DS_INSTANCE_SIGV4_ACCESS_KEY=amazonManagedPrometheus:secure_sigV4AccessKey
+        DS_INSTANCE_SIGV4_SECRET_KEY=amazonManagedPrometheus:secure_sigV4SecretKey
+
+  publish-and-deploy:
+    if: github.ref == 'refs/heads/main'
+    uses: grafana/data-sources-ci-workflows/.github/workflows/cd-dev.yml@d0cd847270085524b96b0e1aebc0cb3efd121c40 # main
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
+    with:
+      go-version: '1.26.5'
+      golangci-lint-version: '2.11.0'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,10 @@
 6. Run the E2E tests (using Playwright and @grafana/plugin-e2e)
 
    Smoke tests run against the local Prometheus in `docker-compose.yaml`. Tests tagged
-   `@aws` use the AMP workspace provisioned for the Data Sources team's AWS test
-   environment (Vault path `amazonManagedPrometheus`). Export those credentials before
-   starting Grafana if you want the live suite to run.
+   `@aws` exercise the AMP workspace provisioned for the Data Sources team's AWS test
+   environment (Vault path `amazonManagedPrometheus`). In CI, Vault injects credentials
+   into the provisioned datasource. Locally, export those credentials before starting
+   Grafana if you want the live suite to run (otherwise `@aws` tests are skipped).
 
    ```bash
    # Install Playwright browsers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,30 @@
 
 6. Run the E2E tests (using Playwright and @grafana/plugin-e2e)
 
+   Smoke tests run against the local Prometheus in `docker-compose.yaml`. Tests tagged
+   `@aws` use the AMP workspace provisioned for the Data Sources team's AWS test
+   environment (Vault path `amazonManagedPrometheus`). Export those credentials before
+   starting Grafana if you want the live suite to run.
+
    ```bash
-   # Spins up a Grafana docker instance (v11.0.0) (port 3000) with an actual Prometheus instance (port 9090)
+   # Install Playwright browsers
+   yarn playwright install --with-deps
+
+   # Optional — required for @aws / live AMP tests (otherwise they are skipped)
+   export DS_INSTANCE_URL=<amp-workspace-url>
+   export DS_INSTANCE_SIGV4_REGION=<region>
+   export DS_INSTANCE_SIGV4_ACCESS_KEY=<access-key>
+   export DS_INSTANCE_SIGV4_SECRET_KEY=<secret-key>
+
+   # Spins up Grafana + a local Prometheus (defaults used when the env vars above are unset)
    yarn run server:configured
 
    # Starts the e2e tests
    yarn run e2e
    ```
+
+   Fork PRs run `playwright.smoke.config.ts`, which excludes `@aws` tests because Vault
+   secrets are unavailable to untrusted workflows.
 
 7. Run the linter
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,3 +21,12 @@ services:
     extends:
       file: .config/docker-compose-base.yaml
       service: grafana
+    environment:
+      # Prevent Grafana 13's splash screen from blocking Playwright.
+      GF_FEATURE_TOGGLES_splashScreen: 'false'
+      # Local defaults keep docker-compose usable without Vault secrets.
+      # PR CI injects real amazonManagedPrometheus values via playwright-secrets.
+      DS_INSTANCE_URL: ${DS_INSTANCE_URL:-http://prometheus:9090}
+      DS_INSTANCE_SIGV4_REGION: ${DS_INSTANCE_SIGV4_REGION:-us-east-2}
+      DS_INSTANCE_SIGV4_ACCESS_KEY: ${DS_INSTANCE_SIGV4_ACCESS_KEY:-abc}
+      DS_INSTANCE_SIGV4_SECRET_KEY: ${DS_INSTANCE_SIGV4_SECRET_KEY:-def}

--- a/e2e/configuration.spec.ts
+++ b/e2e/configuration.spec.ts
@@ -97,33 +97,44 @@ test.describe('Configuration tests', () => {
     readProvisionedDataSource,
     gotoDataSourceConfigPage,
     page,
+    request,
   }) => {
     const ds = await readProvisionedDataSource<DataSourcePluginOptionsEditorProps<PromOptions>>({
       fileName: 'datasources.yml',
     });
     await gotoDataSourceConfigPage(ds.uid);
 
-    const defaultRegion = (ds.jsonData as { sigV4Region?: string }).sigV4Region;
+    // Region comes from $DS_INSTANCE_SIGV4_REGION at Grafana provision time. The YAML
+    // reader in Playwright often does not see that env var, so read it from the API.
+    const apiDs = await request.get(`/api/datasources/uid/${ds.uid}`).then((r) => r.json());
+    const defaultRegion = (apiDs.jsonData as { sigV4Region?: string } | undefined)?.sigV4Region;
     expect(defaultRegion).toBeTruthy();
     await expect(page.getByLabel('Default Region')).toBeVisible();
     await expect(page.getByText(defaultRegion!, { exact: true })).toBeVisible();
   });
 
   test('"Save & test" should fail when configuration is invalid', async ({
-    readProvisionedDataSource,
-    gotoDataSourceConfigPage,
+    createDataSourceConfigPage,
     page,
   }) => {
-    const ds = await readProvisionedDataSource<DataSourcePluginOptionsEditorProps<PromOptions>>({
-      fileName: 'datasources.yml',
+    // Use a throwaway datasource — mutating the provisioned DS would race live @aws tests.
+    const configPage = await createDataSourceConfigPage({
+      type: 'grafana-amazonprometheus-datasource',
+      name: DATA_SOURCE_NAME + '-empty-key',
     });
-    const configPage = await gotoDataSourceConfigPage(ds.uid);
-    await page.getByLabel('Edit Access Key ID').click();
+
+    await configPage
+      .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
+      .fill('https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-invalid');
+    await page.getByRole('combobox', { name: 'Authentication Provider', exact: true }).click();
+    await page.getByText('Access & secret key', { exact: true }).click();
     await page.getByLabel('Access Key ID').fill('');
+    await page.getByLabel('Secret Access Key').fill('fake-secret-key');
+    await page.getByLabel('Default Region').click();
+    await page.getByText('us-east-2', { exact: true }).click();
+
     await expect(configPage.saveAndTest()).not.toBeOK();
-    await expect(configPage).toHaveAlert('error', {
-      hasText: /.*there was an error returned querying the prometheus api/i,
-    });
+    await expect(configPage).toHaveAlert('error');
   });
 
   test('should show an authentication error for invalid access and secret keys', async ({
@@ -138,14 +149,13 @@ test.describe('Configuration tests', () => {
     await configPage
       .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
       .fill('https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-invalid');
+    // New datasources default to a non-keys auth provider; key fields only render for "keys".
+    await page.getByRole('combobox', { name: 'Authentication Provider', exact: true }).click();
+    await page.getByText('Access & secret key', { exact: true }).click();
     await page.getByLabel('Access Key ID').fill('fake-access-key');
     await page.getByLabel('Secret Access Key').fill('fake-secret-key');
-
-    const regionField = page.getByLabel('Default Region');
-    if (await regionField.isVisible().catch(() => false)) {
-      await regionField.click();
-      await page.getByText('us-east-2', { exact: true }).click();
-    }
+    await page.getByLabel('Default Region').click();
+    await page.getByText('us-east-2', { exact: true }).click();
 
     const response = await configPage.saveAndTest();
     expect(response.ok()).toBe(false);

--- a/e2e/configuration.spec.ts
+++ b/e2e/configuration.spec.ts
@@ -93,20 +93,21 @@ test.describe('Configuration tests', () => {
     ).toHaveCount(0);
   });
 
-  /*  test('"Save & test" should be successful when configuration is valid', async ({
-    createDataSourceConfigPage,
+  test('should load the provisioned default region', async ({
     readProvisionedDataSource,
+    gotoDataSourceConfigPage,
+    page,
   }) => {
-    const ds = await readProvisionedDataSource<DataSourcePluginOptionsEditorProps<PromOptions>>({ fileName: 'datasources.yml' });
-    const configPage = await createDataSourceConfigPage({ type: ds.type });
+    const ds = await readProvisionedDataSource<DataSourcePluginOptionsEditorProps<PromOptions>>({
+      fileName: 'datasources.yml',
+    });
+    await gotoDataSourceConfigPage(ds.uid);
 
-    await configPage
-      .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
-      .fill(ds.url || '');
-
-    await expect(configPage.saveAndTest()).toBeOK();
+    const defaultRegion = (ds.jsonData as { sigV4Region?: string }).sigV4Region;
+    expect(defaultRegion).toBeTruthy();
+    await expect(page.getByLabel('Default Region')).toBeVisible();
+    await expect(page.getByText(defaultRegion!, { exact: true })).toBeVisible();
   });
-*/
 
   test('"Save & test" should fail when configuration is invalid', async ({
     readProvisionedDataSource,
@@ -123,6 +124,32 @@ test.describe('Configuration tests', () => {
     await expect(configPage).toHaveAlert('error', {
       hasText: /.*there was an error returned querying the prometheus api/i,
     });
+  });
+
+  test('should show an authentication error for invalid access and secret keys', async ({
+    createDataSourceConfigPage,
+    page,
+  }) => {
+    const configPage = await createDataSourceConfigPage({
+      type: 'grafana-amazonprometheus-datasource',
+      name: DATA_SOURCE_NAME + '-bad-keys',
+    });
+
+    await configPage
+      .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
+      .fill('https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-invalid');
+    await page.getByLabel('Access Key ID').fill('fake-access-key');
+    await page.getByLabel('Secret Access Key').fill('fake-secret-key');
+
+    const regionField = page.getByLabel('Default Region');
+    if (await regionField.isVisible().catch(() => false)) {
+      await regionField.click();
+      await page.getByText('us-east-2', { exact: true }).click();
+    }
+
+    const response = await configPage.saveAndTest();
+    expect(response.ok()).toBe(false);
+    await expect(configPage).toHaveAlert('error');
   });
 
   test('"Save & test" should fail when url is empty', async ({

--- a/e2e/live-query.spec.ts
+++ b/e2e/live-query.spec.ts
@@ -1,5 +1,4 @@
 /// <reference types="node" />
-import { selectors } from '@grafana/e2e-selectors';
 import { expect, test } from '@grafana/plugin-e2e';
 import type { Page, Response } from '@playwright/test';
 
@@ -13,20 +12,11 @@ const CLOUD_DEFAULT_UID = 'amazon-managed-prometheus-ds-m';
 // GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud).
 const isCloudRun = !!process.env.GRAFANA_URL;
 
-const hasLiveCredentials = Boolean(
-  process.env.DS_INSTANCE_URL &&
-    process.env.DS_INSTANCE_SIGV4_ACCESS_KEY &&
-    process.env.DS_INSTANCE_SIGV4_SECRET_KEY &&
-    // Local docker-compose defaults point at the in-compose Prometheus — not a live AMP workspace.
-    !process.env.DS_INSTANCE_URL.includes('prometheus:9090') &&
-    !process.env.DS_INSTANCE_URL.includes('localhost')
-);
-
-const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
-
-async function configurePDC(page: Page, networkName: string) {
-  await page.getByRole('combobox', { name: 'Private data source connect' }).click();
-  await page.getByText(networkName, { exact: true }).click();
+function isLocalPrometheusUrl(url: string | undefined): boolean {
+  if (!url) {
+    return true;
+  }
+  return url.includes('prometheus:9090') || url.includes('localhost') || url.includes('127.0.0.1');
 }
 
 // Waits for the first /api/ds/query response where results.A.frames is an array.
@@ -68,46 +58,32 @@ test.describe('Live AMP against real workspace', () => {
   // Live AMP health checks / queries can exceed the default 15s suite timeout.
   test.describe.configure({ mode: 'serial', timeout: 60000 });
 
-  test.beforeEach(() => {
+  test.beforeEach(async ({ readProvisionedDataSource }) => {
     // Fork PRs use playwright.smoke.config.ts (grepInvert /@aws/) so these never run there.
-    // Locally, skip unless Vault-style live credentials are exported.
+    // Trusted CI injects Vault secrets into the provisioned datasource via docker-compose —
+    // do not gate on process.env (Playwright often does not see those vars).
+    // Locally, skip when the provisioned URL still points at the in-compose Prometheus.
+    if (isCloudRun || process.env.CI) {
+      return;
+    }
+    const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
     test.skip(
-      !hasLiveCredentials && !isCloudRun,
-      'Live AMP credentials (DS_INSTANCE_*) or Cloud GRAFANA_URL required — see CONTRIBUTING.md'
+      isLocalPrometheusUrl(ds.url),
+      'Live AMP credentials required — export DS_INSTANCE_* before yarn server (see CONTRIBUTING.md)'
     );
   });
 
   test(
-    'save & test passes with live credentials',
+    'provisioned datasource passes save & test',
     { tag: '@aws' },
-    async ({ createDataSourceConfigPage, page }) => {
-      // On DSE2EDEV, prefer the managed datasource query coverage below — ad-hoc DS
-      // health checks through PDC from a fresh config page are flaky (see clickhouse e2e).
-      test.skip(isCloudRun, 'Ad-hoc save & test on DSE2EDEV is covered by the managed datasource query test');
-      test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
+    async ({ readProvisionedDataSource, gotoDataSourceConfigPage }) => {
+      // On DSE2EDEV the local provisioning file is not applied; managed DS query covers connectivity.
+      test.skip(isCloudRun, 'Ad-hoc provisioned save & test is not available on DSE2EDEV');
 
-      const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+      const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
+      const configPage = await gotoDataSourceConfigPage(ds.uid);
 
-      await configPage
-        .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
-        .fill(process.env.DS_INSTANCE_URL!);
-
-      // SIGV4 auth is selected by default for AMP; fill keys + region from Vault.
-      await page.getByLabel('Access Key ID').fill(process.env.DS_INSTANCE_SIGV4_ACCESS_KEY!);
-      await page.getByLabel('Secret Access Key').fill(process.env.DS_INSTANCE_SIGV4_SECRET_KEY!);
-
-      const region = process.env.DS_INSTANCE_SIGV4_REGION;
-      if (region) {
-        const regionField = page.getByLabel('Default Region');
-        await expect(regionField).toBeVisible();
-        await regionField.click();
-        await page.getByText(region, { exact: true }).click();
-      }
-
-      if (process.env.DS_PDC_NETWORK_NAME) {
-        await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
-      }
-
+      // Credentials come from provisioning ($DS_INSTANCE_*), already loaded into Grafana.
       const response = await configPage.saveAndTest();
       expect(response.ok()).toBe(true);
     }
@@ -117,11 +93,9 @@ test.describe('Live AMP against real workspace', () => {
     'PromQL query against live AMP returns frames',
     { tag: '@aws' },
     async ({ page, readProvisionedDataSource }) => {
-      let uid = DATASOURCE_UID;
+      let uid = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
       if (!isCloudRun) {
-        test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
-        // Prefer the provisioned datasource uid when available (PR CI with playwright-secrets).
         const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
         uid = ds.uid || LOCAL_DEFAULT_UID;
       }

--- a/e2e/live-query.spec.ts
+++ b/e2e/live-query.spec.ts
@@ -69,67 +69,71 @@ test.describe('Live AMP against real workspace', () => {
   test.describe.configure({ mode: 'serial', timeout: 60000 });
 
   test.beforeEach(() => {
+    // Fork PRs use playwright.smoke.config.ts (grepInvert /@aws/) so these never run there.
+    // Locally, skip unless Vault-style live credentials are exported.
     test.skip(
       !hasLiveCredentials && !isCloudRun,
-      'Live AMP credentials (DS_INSTANCE_*) or Cloud GRAFANA_URL required'
+      'Live AMP credentials (DS_INSTANCE_*) or Cloud GRAFANA_URL required — see CONTRIBUTING.md'
     );
   });
 
-  test('save & test passes with live credentials', async ({ createDataSourceConfigPage, page }) => {
-    // On DSE2EDEV, prefer the managed datasource query coverage below — ad-hoc DS
-    // health checks through PDC from a fresh config page are flaky (see clickhouse e2e).
-    test.skip(isCloudRun, 'Ad-hoc save & test on DSE2EDEV is covered by the managed datasource query test');
-    test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
+  test(
+    'save & test passes with live credentials',
+    { tag: '@aws' },
+    async ({ createDataSourceConfigPage, page }) => {
+      // On DSE2EDEV, prefer the managed datasource query coverage below — ad-hoc DS
+      // health checks through PDC from a fresh config page are flaky (see clickhouse e2e).
+      test.skip(isCloudRun, 'Ad-hoc save & test on DSE2EDEV is covered by the managed datasource query test');
+      test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
 
-    const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+      const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
 
-    await configPage
-      .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
-      .fill(process.env.DS_INSTANCE_URL!);
+      await configPage
+        .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
+        .fill(process.env.DS_INSTANCE_URL!);
 
-    // SIGV4 auth is selected by default for AMP; fill keys + region from Vault.
-    await page.getByLabel('Access Key ID').fill(process.env.DS_INSTANCE_SIGV4_ACCESS_KEY!);
-    await page.getByLabel('Secret Access Key').fill(process.env.DS_INSTANCE_SIGV4_SECRET_KEY!);
+      // SIGV4 auth is selected by default for AMP; fill keys + region from Vault.
+      await page.getByLabel('Access Key ID').fill(process.env.DS_INSTANCE_SIGV4_ACCESS_KEY!);
+      await page.getByLabel('Secret Access Key').fill(process.env.DS_INSTANCE_SIGV4_SECRET_KEY!);
 
-    const region = process.env.DS_INSTANCE_SIGV4_REGION;
-    if (region) {
-      const regionField = page.getByLabel('Default Region');
-      if (await regionField.isVisible().catch(() => false)) {
+      const region = process.env.DS_INSTANCE_SIGV4_REGION;
+      if (region) {
+        const regionField = page.getByLabel('Default Region');
+        await expect(regionField).toBeVisible();
         await regionField.click();
         await page.getByText(region, { exact: true }).click();
       }
+
+      if (process.env.DS_PDC_NETWORK_NAME) {
+        await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+      }
+
+      const response = await configPage.saveAndTest();
+      expect(response.ok()).toBe(true);
     }
+  );
 
-    if (process.env.DS_PDC_NETWORK_NAME) {
-      await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+  test(
+    'PromQL query against live AMP returns frames',
+    { tag: '@aws' },
+    async ({ page, readProvisionedDataSource }) => {
+      let uid = DATASOURCE_UID;
+
+      if (!isCloudRun) {
+        test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
+        // Prefer the provisioned datasource uid when available (PR CI with playwright-secrets).
+        const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
+        uid = ds.uid || LOCAL_DEFAULT_UID;
+      }
+
+      // `up` is scraped into AMP by the agentless scraper on the provisioned workspace.
+      const responsePromise = waitForMainQueryResponse(page);
+      await page.goto(exploreUrl(uid, 'up'));
+      const { response, body } = await responsePromise;
+
+      expect(response.ok()).toBe(true);
+      expect(body.results?.A?.error).toBeUndefined();
+      expect(body.results?.A?.frames?.length).toBeGreaterThan(0);
     }
-
-    const response = await configPage.saveAndTest();
-    expect(response.ok()).toBe(true);
-  });
-
-  test('PromQL query against live AMP returns frames', async ({
-    page,
-    readProvisionedDataSource,
-  }) => {
-    let uid = DATASOURCE_UID;
-
-    if (!isCloudRun) {
-      test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
-      // Prefer the provisioned datasource uid when available (PR CI with playwright-secrets).
-      const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
-      uid = ds.uid || LOCAL_DEFAULT_UID;
-    }
-
-    // `up` is scraped into AMP by the agentless scraper on the provisioned workspace.
-    // Falls back to an empty-but-successful result shape if the scraper is lagging —
-    // we still assert HTTP OK and a frames array (no query error).
-    const responsePromise = waitForMainQueryResponse(page);
-    await page.goto(exploreUrl(uid, 'up'));
-    const { response, body } = await responsePromise;
-
-    expect(response.ok()).toBe(true);
-    expect(body.results?.A?.error).toBeUndefined();
-    expect(Array.isArray(body.results?.A?.frames)).toBe(true);
-  });
+  );
 });

--- a/e2e/live-query.spec.ts
+++ b/e2e/live-query.spec.ts
@@ -1,0 +1,135 @@
+/// <reference types="node" />
+import { selectors } from '@grafana/e2e-selectors';
+import { expect, test } from '@grafana/plugin-e2e';
+import type { Page, Response } from '@playwright/test';
+
+const PLUGIN_TYPE = 'grafana-amazonprometheus-datasource';
+const PROVISIONED_FILE = 'datasources.yml';
+const LOCAL_DEFAULT_UID = 'grafana-amazonprometheus';
+// Managed datasource on DSE2EDEV from data-sources infra
+// (createDataSource('amazon-managed-prometheus', ...) → amazon-managed-prometheus-ds-m).
+const CLOUD_DEFAULT_UID = 'amazon-managed-prometheus-ds-m';
+
+// GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud).
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const hasLiveCredentials = Boolean(
+  process.env.DS_INSTANCE_URL &&
+    process.env.DS_INSTANCE_SIGV4_ACCESS_KEY &&
+    process.env.DS_INSTANCE_SIGV4_SECRET_KEY &&
+    // Local docker-compose defaults point at the in-compose Prometheus — not a live AMP workspace.
+    !process.env.DS_INSTANCE_URL.includes('prometheus:9090') &&
+    !process.env.DS_INSTANCE_URL.includes('localhost')
+);
+
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+
+async function configurePDC(page: Page, networkName: string) {
+  await page.getByRole('combobox', { name: 'Private data source connect' }).click();
+  await page.getByText(networkName, { exact: true }).click();
+}
+
+// Waits for the first /api/ds/query response where results.A.frames is an array.
+// response.json() must be called inside the predicate while the CDP body is still live.
+async function waitForMainQueryResponse(page: Page): Promise<{ response: Response; body: any }> {
+  let body: any;
+  const response = await page.waitForResponse(async (r: Response) => {
+    if (!r.url().includes('/api/ds/query') || !r.ok()) {
+      return false;
+    }
+    const b = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b;
+    return true;
+  });
+  return { response, body };
+}
+
+function exploreUrl(uid: string, expr: string): string {
+  const panes = JSON.stringify({
+    explore: {
+      datasource: uid,
+      queries: [
+        {
+          refId: 'A',
+          expr,
+          datasource: { type: PLUGIN_TYPE, uid },
+        },
+      ],
+      range: { from: 'now-1h', to: 'now' },
+    },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+test.describe('Live AMP against real workspace', () => {
+  // Live AMP health checks / queries can exceed the default 15s suite timeout.
+  test.describe.configure({ mode: 'serial', timeout: 60000 });
+
+  test.beforeEach(() => {
+    test.skip(
+      !hasLiveCredentials && !isCloudRun,
+      'Live AMP credentials (DS_INSTANCE_*) or Cloud GRAFANA_URL required'
+    );
+  });
+
+  test('save & test passes with live credentials', async ({ createDataSourceConfigPage, page }) => {
+    // On DSE2EDEV, prefer the managed datasource query coverage below — ad-hoc DS
+    // health checks through PDC from a fresh config page are flaky (see clickhouse e2e).
+    test.skip(isCloudRun, 'Ad-hoc save & test on DSE2EDEV is covered by the managed datasource query test');
+    test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
+
+    const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+
+    await configPage
+      .getByGrafanaSelector(selectors.components.DataSource.Prometheus.configPage.connectionSettings)
+      .fill(process.env.DS_INSTANCE_URL!);
+
+    // SIGV4 auth is selected by default for AMP; fill keys + region from Vault.
+    await page.getByLabel('Access Key ID').fill(process.env.DS_INSTANCE_SIGV4_ACCESS_KEY!);
+    await page.getByLabel('Secret Access Key').fill(process.env.DS_INSTANCE_SIGV4_SECRET_KEY!);
+
+    const region = process.env.DS_INSTANCE_SIGV4_REGION;
+    if (region) {
+      const regionField = page.getByLabel('Default Region');
+      if (await regionField.isVisible().catch(() => false)) {
+        await regionField.click();
+        await page.getByText(region, { exact: true }).click();
+      }
+    }
+
+    if (process.env.DS_PDC_NETWORK_NAME) {
+      await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+    }
+
+    const response = await configPage.saveAndTest();
+    expect(response.ok()).toBe(true);
+  });
+
+  test('PromQL query against live AMP returns frames', async ({
+    page,
+    readProvisionedDataSource,
+  }) => {
+    let uid = DATASOURCE_UID;
+
+    if (!isCloudRun) {
+      test.skip(!hasLiveCredentials, 'DS_INSTANCE_* secrets required');
+      // Prefer the provisioned datasource uid when available (PR CI with playwright-secrets).
+      const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
+      uid = ds.uid || LOCAL_DEFAULT_UID;
+    }
+
+    // `up` is scraped into AMP by the agentless scraper on the provisioned workspace.
+    // Falls back to an empty-but-successful result shape if the scraper is lagging —
+    // we still assert HTTP OK and a frames array (no query error).
+    const responsePromise = waitForMainQueryResponse(page);
+    await page.goto(exploreUrl(uid, 'up'));
+    const { response, body } = await responsePromise;
+
+    expect(response.ok()).toBe(true);
+    expect(body.results?.A?.error).toBeUndefined();
+    expect(Array.isArray(body.results?.A?.frames)).toBe(true);
+  });
+});

--- a/e2e/live-query.spec.ts
+++ b/e2e/live-query.spec.ts
@@ -74,18 +74,19 @@ test.describe('Live AMP against real workspace', () => {
   });
 
   test(
-    'provisioned datasource passes save & test',
+    'provisioned datasource passes health check',
     { tag: '@aws' },
-    async ({ readProvisionedDataSource, gotoDataSourceConfigPage }) => {
+    async ({ readProvisionedDataSource, request }) => {
       // On DSE2EDEV the local provisioning file is not applied; managed DS query covers connectivity.
-      test.skip(isCloudRun, 'Ad-hoc provisioned save & test is not available on DSE2EDEV');
+      test.skip(isCloudRun, 'Ad-hoc provisioned health check is not available on DSE2EDEV');
 
       const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
-      const configPage = await gotoDataSourceConfigPage(ds.uid);
 
-      // Credentials come from provisioning ($DS_INSTANCE_*), already loaded into Grafana.
-      const response = await configPage.saveAndTest();
-      expect(response.ok()).toBe(true);
+      // Probe the health API directly — Save & test on an editable provisioned DS can
+      // rewrite secure fields and is flaky; the health endpoint uses the stored credentials.
+      const response = await request.get(`/api/datasources/uid/${ds.uid}/health`);
+      const body = await response.json();
+      expect(body, JSON.stringify(body)).toMatchObject({ status: 'OK' });
     }
   );
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,4 @@
+import type { PluginOptions } from '@grafana/plugin-e2e';
 import { defineConfig, devices } from '@playwright/test';
 import { dirname } from 'path';
 
@@ -12,7 +13,7 @@ const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
+export default defineConfig<PluginOptions>({
   testDir: './e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -29,7 +30,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL: process.env.GRAFANA_URL || 'http://127.0.0.1:3000',
     featureToggles: {
       dashboardNewLayouts: false,
     },
@@ -57,7 +58,7 @@ export default defineConfig({
       name: 'run-tests',
       use: {
         ...devices['Desktop Chrome'],
-        storageState: 'playwright/.auth/admin.json',
+        storageState: `playwright/.auth/${process.env.GRAFANA_ADMIN_USER || 'admin'}.json`,
       },
       dependencies: ['auth'],
     },

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+import baseConfig from './playwright.config';
+
+// Used for fork PRs where Vault secrets are unavailable (isTrusted=false).
+// Excludes tests tagged `@aws` that need the provisioned live AMP workspace.
+export default defineConfig(baseConfig, {
+  grepInvert: /@aws/,
+});

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -1,25 +1,26 @@
 apiVersion: 1
 
 datasources:
-- name: Amazon Managed Service for Prometheus
-  uid: grafana-amazonprometheus
-  type: grafana-amazonprometheus-datasource
-  url: http://prometheus:9090
-  access: proxy
-  editable: true
-  jsonData:
-    # httpMethod: POST
-    # manageAlerts: true
-    # prometheusType: Prometheus
-    # prometheusVersion: 2.44.0
-    # cacheLevel: 'High'
-    # disableRecordingRules: false
-    # incrementalQueryOverlapWindow: 10m
-    defaultEditor: builder
-    sigV4Auth: true
-    sigV4AuthType: keys
-    sigv4Service: aps
-    externalId: externalId
-  secureJsonData:
-      sigV4AccessKey: abc
-      sigV4SecretKey: def
+  - name: Amazon Managed Service for Prometheus
+    uid: grafana-amazonprometheus
+    type: grafana-amazonprometheus-datasource
+    url: $DS_INSTANCE_URL
+    access: proxy
+    editable: true
+    jsonData:
+      # httpMethod: POST
+      # manageAlerts: true
+      # prometheusType: Prometheus
+      # prometheusVersion: 2.44.0
+      # cacheLevel: 'High'
+      # disableRecordingRules: false
+      # incrementalQueryOverlapWindow: 10m
+      defaultEditor: builder
+      sigV4Auth: true
+      sigV4AuthType: keys
+      sigV4Region: $DS_INSTANCE_SIGV4_REGION
+      sigv4Service: aps
+      externalId: externalId
+    secureJsonData:
+      sigV4AccessKey: $DS_INSTANCE_SIGV4_ACCESS_KEY
+      sigV4SecretKey: $DS_INSTANCE_SIGV4_SECRET_KEY


### PR DESCRIPTION
- Add config, health, and PromQL up E2E coverage for #725
- Inject Vault secrets into trusted runs, use smoke-only fork configuration, and deploy main to DSE2EDEV
- Checks: lint, typecheck, and 45 Jest tests pass