### PR TITLE
Prepare release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.2.0
 
+- chore(deps): bump promlib to v0.0.18 to fix Prometheus build-info health check 405
 - AMP: expose query statistics in [#785](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/785)
 - Update dependencies in [#796](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/796)
 - Bump @grafana/* to 13.1.1 and update dependencies in [#795](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/795)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 3.2.0
+
+- AMP: expose query statistics in [#785](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/785)
+- Update dependencies in [#796](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/796)
+- Bump @grafana/* to 13.1.1 and update dependencies in [#795](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/795)
+- Bump dependencies in [#794](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/794)
+- fix: preserve PromQL queries when switching a panel from a Prometheus data source to AMP in [#775](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/775)
+- chore(deps): bump fast-uri from 3.1.3 to 3.1.4 in [#792](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/792)
+- Dependency updates in [#791](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/791)
+- chore(deps): update grafana/grafana-enterprise:latest docker digest to b92dd30 in [#788](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/788)
+- fix(deps): update backend dependencies in [#782](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/782)
+- chore(deps): update actions/setup-node action to v7 in [#783](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/783)
+- ci: use shared reusable add-to-project workflow in [#787](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/787)
+- ci: use shared reusable stale workflow in [#786](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/786)
+- chore(deps): update frontend dependencies to v8.64.0 in [#781](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/781)
+- fix(deps): update frontend dependencies in [#776](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/776)
+- ci: add stale issue and PR workflow in [#777](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/777)
+- chore(deps): lock file maintenance frontend dependencies in [#771](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/771)
+- chore(deps): update docker dependencies in [#767](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/767)
+- chore(deps): update babel monorepo to v8 in [#765](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/765)
+- fix(deps): update frontend dependencies in [#768](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/768)
+- chore: use shared data-sources Renovate base preset in [#774](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/774)
+- Add add-to-project workflow and remove issue_commands in [#773](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/773)
+- Docs: Updated Amazon Managed Prometheus docs in [#752](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/752)
+- chore: bump plugin CI/CD workflows to v10.1.0 in [#766](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/766)
+- fix(deps): update frontend dependencies in [#747](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/747)
+
 ## 3.1.0
 
 - feat: forward logged-in Grafana user identity headers to Amazon Managed Service for Prometheus in [#751](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/751)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/grafana/grafana-aws-sdk v1.5.1
 	github.com/grafana/grafana-plugin-sdk-go v0.294.0
-	github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.17
+	github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.18
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/grafana/grafana-aws-sdk v1.5.1 h1:qvqZwc2tzWCj5UAICmj+dYpa9ZQU9DY+zdW
 github.com/grafana/grafana-aws-sdk v1.5.1/go.mod h1:9n7/73i1L6E33ozMk2Nb2s4OoOSWqbmYltIoi/AqgJw=
 github.com/grafana/grafana-plugin-sdk-go v0.294.0 h1:0GQQXCfot1rArDGM98ORKVhpx/BHreeL1Zlha/4qChE=
 github.com/grafana/grafana-plugin-sdk-go v0.294.0/go.mod h1:UZfMMraG1cyxYOx9dONSidwZUjfgbWVj9Cb2bMFFsWU=
-github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.17 h1:f/k6WY/KyoR6FxupLLFrlaHa0yv0Ox+qdat33j8Mbus=
-github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.17/go.mod h1:RuLfmZu2CGtcZObqslhf8vKnqlJdQVsVn7GTCBKPW9g=
+github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.18 h1:5MceBd5dunxNjWbH3XECyGZEdborkqExVYHx1IVQUDs=
+github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.18/go.mod h1:kQTcZL+iotYO1NcHD2lUxJtguxMvrnTi7XSLW4c3T7U=
 github.com/grafana/grafana/apps/scope v0.0.0-20260427171703-d4f46decefcb h1:f71QY1XosITgThiADvcRvK932A0TUSTTlbhhzvjtpg4=
 github.com/grafana/grafana/apps/scope v0.0.0-20260427171703-d4f46decefcb/go.mod h1:Jk+o778Rv0Rv4EDYlpB8UtMXaWbU7zGbTSVU1Z99a7U=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-amazonprometheus-datasource",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A plugin for Amazon Managed Prometheus",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Bump version to `3.2.0` in `package.json`
- Update `CHANGELOG.md` with all changes since [v3.1.0](https://github.com/grafana/grafana-amazonprometheus-datasource/releases/tag/v3.1.0) (released 2026-06-23)
- Checks: yarn spellcheck passed; 24/24 changelog entries match commits since tag
